### PR TITLE
Extend Documents module to all establishments with upload, listing, deletion and JWT strategy refactor – Issue #24

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -7,7 +7,6 @@ import { CreateUserDto } from '../users/dto/create-user.dto';
 import * as bcrypt from 'bcryptjs';
 import { JwtPayload } from './interfaces/jwt-payload.interface';
 import { AuthResponseDto } from './dto/auth-response.dto';
-import { Establishment } from '../establishments/entities/establishment.entity';
 
 @Injectable()
 export class AuthService {
@@ -21,7 +20,7 @@ export class AuthService {
     const user = await this.usersService.create(createUserDto);
     await this.usersService.updateLastLogin(user.id);
 
-    return this.buildAuthResponse(user, null);
+    return this.buildAuthResponse(user);
   }
 
   // Login user
@@ -44,18 +43,13 @@ export class AuthService {
 
     await this.usersService.updateLastLogin(user.id);
 
-    return this.buildAuthResponse(user, user.establishment);
+    return this.buildAuthResponse(user);
   }
 
-  private buildAuthResponse(
-    user: User,
-    establishment: Establishment | null,
-  ): AuthResponseDto {
+  private buildAuthResponse(user: User): AuthResponseDto {
     const payload: JwtPayload = {
       sub: user.id,
       role: user.role,
-      establishmentId: user.establishmentId,
-      establishmentType: establishment?.type ?? null,
     };
 
     return {
@@ -64,7 +58,7 @@ export class AuthService {
         id: user.id,
         role: user.role,
         establishmentId: user.establishmentId,
-        establishmentType: establishment?.type ?? null,
+        establishmentType: user.establishment?.type ?? null,
       },
     };
   }

--- a/backend/src/auth/interfaces/jwt-payload.interface.ts
+++ b/backend/src/auth/interfaces/jwt-payload.interface.ts
@@ -1,9 +1,6 @@
-import { EstablishmentType } from 'src/establishments/enums/establishment-type.enum';
 import { UserRole } from '../../users/enums/user-role.enum';
 
 export interface JwtPayload {
   sub: number; // user ID
   role: UserRole;
-  establishmentId: number | null;
-  establishmentType: EstablishmentType | null;
 }

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -4,10 +4,14 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { JwtPayload } from '../interfaces/jwt-payload.interface';
 import { AuthenticatedUser } from '../interfaces/authenticated-user.interface';
 import { ConfigService } from '@nestjs/config';
+import { UsersService } from '../../users/users.service';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(configService: ConfigService) {
+  constructor(
+    configService: ConfigService,
+    private readonly usersService: UsersService,
+  ) {
     const secret = configService.get<string>('JWT_SECRET');
     if (!secret) {
       throw new Error('JWT_SECRET must be defined in environment variables');
@@ -20,12 +24,14 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  validate(payload: JwtPayload): AuthenticatedUser {
+  async validate(payload: JwtPayload): Promise<AuthenticatedUser> {
+    const user = await this.usersService.findOne(payload.sub);
+
     return {
-      id: payload.sub,
-      role: payload.role,
-      establishmentId: payload.establishmentId,
-      establishmentType: payload.establishmentType,
+      id: user.id,
+      role: user.role,
+      establishmentId: user.establishmentId,
+      establishmentType: user.establishment?.type ?? null,
     };
   }
 }

--- a/backend/src/config/storage.config.ts
+++ b/backend/src/config/storage.config.ts
@@ -7,8 +7,8 @@ export const UPLOAD_DIR = 'uploads';
 export const UPLOAD_PATH = join(process.cwd(), UPLOAD_DIR);
 
 // Subdirectories for public and private uploads
-export const PUBLIC_UPLOAD_PATH = join(UPLOAD_PATH, 'public', 'suppliers');
-export const PRIVATE_UPLOAD_PATH = join(UPLOAD_PATH, 'private', 'messages');
+export const PUBLIC_UPLOAD_PATH = join(UPLOAD_PATH, 'public', 'documents');
+export const PRIVATE_UPLOAD_PATH = join(UPLOAD_PATH, 'private', 'attachments');
 
 // Public static url prefix for accessing uploaded public files
 export const PUBLIC_STATIC_URL_PREFIX = '/documents';

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -1,88 +1,140 @@
 import {
-  //   Body,
+  Body,
   Controller,
-  //   HttpStatus,
-  //   Param,
-  //   ParseFilePipeBuilder,
-  //   ParseIntPipe,
-  //   Post,
-  //   UploadedFile,
-  //   UseInterceptors,
+  Delete,
+  ForbiddenException,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseFilePipeBuilder,
+  ParseIntPipe,
+  Post,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
-// import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
-// import { CurrentUser } from '../common/decorators/current-user.decorator';
-// import { CreateSupplierDocumentDto } from '../documents/dto/create-document.dto';
-// import {
-//   ApiBadRequestResponse,
-//   ApiBearerAuth,
-//   ApiBody,
-//   ApiConsumes,
-//   ApiForbiddenResponse,
-//   ApiNotFoundResponse,
-//   ApiOkResponse,
-//   ApiTags,
-//   ApiUnprocessableEntityResponse,
-// } from '@nestjs/swagger';
-// import { FileInterceptor } from '@nestjs/platform-express/multer/interceptors/file.interceptor';
-// import { multerPublicOptions } from '../config/multer.config';
-// import { DocumentCategory } from '../documents/enums/document.enum';
-// import { SupplierDocumentResponseDto } from '../documents/dto/document-response.dto';
+import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { CreateDocumentDto } from '../documents/dto/create-document.dto';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiTags,
+  ApiUnprocessableEntityResponse,
+} from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express/multer/interceptors/file.interceptor';
+import { multerPublicOptions } from '../config/multer.config';
+import { DocumentCategory } from '../documents/enums/document.enum';
+import { DocumentResponseDto } from '../documents/dto/document-response.dto';
 import { DocumentsService } from './documents.service';
+import { GroupedDocumentsResponseDto } from './dto/grouped-documents-response.dto';
 
-// @ApiTags('supplier-documents')
-// @ApiBearerAuth()
-@Controller('suppliers/:id/documents')
+@ApiTags('documents')
+@ApiBearerAuth()
+@Controller('documents')
 export class DocumentsController {
   constructor(private readonly documentsService: DocumentsService) {}
 
-  // @Post()
-  // @ApiOkResponse({ type: SupplierDocumentResponseDto })
-  // @ApiBadRequestResponse({
-  //   description: 'Invalid file type or category limit reached',
-  // })
-  // @ApiForbiddenResponse({ description: 'Only suppliers can upload documents' })
-  // @ApiNotFoundResponse({
-  //   description: 'Supplier not found or not owned by user',
-  // })
-  // @ApiUnprocessableEntityResponse({
-  //   description: 'File validation failed (size, format)',
-  // })
-  // @ApiConsumes('multipart/form-data')
-  // @ApiBody({
-  //   schema: {
-  //     type: 'object',
-  //     properties: {
-  //       file: {
-  //         type: 'string',
-  //         format: 'binary',
-  //       },
-  //       category: {
-  //         type: 'string',
-  //         enum: Object.values(DocumentCategory),
-  //       },
-  //     },
-  //   },
-  // })
-  // @UseInterceptors(FileInterceptor('file', multerPublicOptions))
-  // async upload(
-  //   @Param('id', ParseIntPipe) supplierId: number,
-  //   @CurrentUser() user: AuthenticatedUser,
-  //   @UploadedFile(
-  //     new ParseFilePipeBuilder()
-  //       .addMaxSizeValidator({
-  //         maxSize: 10 * 1024 * 1024, // 10MB
-  //       })
-  //       .build({
-  //         errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
-  //       }),
-  //   )
-  //   file: Express.Multer.File,
-  //   @Body() dto: CreateSupplierDocumentDto,
-  // ) {
-  //   return this.documentsService.upload(
-  //     user.establishmentId,
-  //     file,
-  //     dto.category,
-  //   );
-  // }
+  @Post()
+  @ApiOkResponse({ type: DocumentResponseDto })
+  @ApiBadRequestResponse({
+    description: 'Invalid file type or category limit reached',
+  })
+  @ApiForbiddenResponse({
+    description:
+      'No establishment, or category not allowed for your establishment type',
+  })
+  @ApiUnprocessableEntityResponse({
+    description: 'File validation failed (size, format)',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+        },
+        category: {
+          type: 'string',
+          enum: Object.values(DocumentCategory),
+        },
+      },
+    },
+  })
+  @UseInterceptors(FileInterceptor('file', multerPublicOptions))
+  async upload(
+    @CurrentUser() user: AuthenticatedUser,
+    @UploadedFile(
+      new ParseFilePipeBuilder()
+        .addMaxSizeValidator({
+          maxSize: 10 * 1024 * 1024, // 10MB
+        })
+        .build({
+          errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        }),
+    )
+    file: Express.Multer.File,
+    @Body() dto: CreateDocumentDto,
+  ) {
+    if (user.establishmentId === null) {
+      throw new ForbiddenException(
+        'You must create an establishment before managing documents',
+      );
+    }
+
+    return this.documentsService.upload(
+      user.establishmentId,
+      user.establishmentType,
+      file,
+      dto.category,
+    );
+  }
+
+  @Get()
+  @ApiOkResponse({
+    description: 'Documents grouped by category',
+    type: GroupedDocumentsResponseDto,
+  })
+  @ApiForbiddenResponse({
+    description: 'You must create an establishment before managing documents',
+  })
+  async findAll(
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<GroupedDocumentsResponseDto> {
+    if (user.establishmentId === null) {
+      throw new ForbiddenException(
+        'You must create an establishment before managing documents',
+      );
+    }
+
+    return this.documentsService.findAllByEstablishment(user.establishmentId);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContentResponse({ description: 'Document deleted successfully' })
+  @ApiNotFoundResponse({ description: 'Document not found' })
+  @ApiForbiddenResponse({
+    description: 'You must create an establishment before managing documents',
+  })
+  async delete(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', ParseIntPipe) documentId: number,
+  ) {
+    if (user.establishmentId === null) {
+      throw new ForbiddenException(
+        'You must create an establishment before managing documents',
+      );
+    }
+
+    return this.documentsService.delete(documentId, user.establishmentId);
+  }
 }

--- a/backend/src/documents/documents.module.ts
+++ b/backend/src/documents/documents.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { DocumentsService } from './documents.service';
 import { DocumentsController } from './documents.controller';
 import { FilesModule } from '../files/files.module';
-import { TypeOrmModule } from '@nestjs/typeorm/dist/typeorm.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { Document } from './entities/document.entity';
 
 @Module({

--- a/backend/src/documents/documents.service.ts
+++ b/backend/src/documents/documents.service.ts
@@ -1,90 +1,164 @@
-// import { BadRequestException, Injectable } from '@nestjs/common';
-// import { InjectRepository } from '@nestjs/typeorm';
-// import { Document } from '../documents/entities/document.entity';
-// import { DocumentCategory } from '../documents/enums/document.enum';
-// import { Repository } from 'typeorm';
-// import { FilesService } from '../files/files.service';
-
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Document } from '../documents/entities/document.entity';
+import { DocumentCategory } from '../documents/enums/document.enum';
+import { Repository } from 'typeorm';
+import { FilesService } from '../files/files.service';
+import { EstablishmentType } from '../establishments/enums/establishment-type.enum';
+import { DocumentResponseDto } from './dto/document-response.dto';
+import { GroupedDocumentsResponseDto } from './dto/grouped-documents-response.dto';
 
 @Injectable()
 export class DocumentsService {
-  // constructor(
-  //   @InjectRepository(Document)
-  //   private documentsRepository: Repository<Document>,
-  //   private readonly filesService: FilesService,
-  // ) {}
-  // // Number of allowed documents for each category
-  // private readonly CATEGORY_LIMITS: Record<DocumentCategory, number> = {
-  //   [DocumentCategory.LOGO]: 1,
-  //   [DocumentCategory.COVER_PHOTO]: 1,
-  //   [DocumentCategory.CATALOG]: 1,
-  //   [DocumentCategory.GALLERY_PHOTO]: 6,
-  // };
-  // // Allowed mime types for each category
-  // private readonly CATEGORY_ALLOWED_MIME_TYPES: Record<
-  //   DocumentCategory,
-  //   string[]
-  // > = {
-  //   [DocumentCategory.LOGO]: ['image/png', 'image/jpeg', 'image/webp'],
-  //   [DocumentCategory.COVER_PHOTO]: ['image/png', 'image/jpeg', 'image/webp'],
-  //   [DocumentCategory.CATALOG]: ['application/pdf'],
-  //   [DocumentCategory.GALLERY_PHOTO]: ['image/png', 'image/jpeg', 'image/webp'],
-  // };
-  // // Upload a supplier document(with category-specific rules)
-  // async upload(
-  //   establishmentId: number,
-  //   userId: number,
-  //   file: Express.Multer.File,
-  //   category: DocumentCategory,
-  // ) {
-  //   await this.suppliersService.verifyOwnership(supplierId, userId);
-  //   this.validateMimeTypeForCategory(file, category);
-  //   await this.checkCategoryLimit(supplierId, category);
-  //   const storedFile = await this.filesService.create(file);
-  //   const supplierDocument = this.supplierDocumentsRepository.create({
-  //     supplierId,
-  //     fileId: storedFile.id,
-  //     category,
-  //   });
-  //   const savedDocument =
-  //     await this.supplierDocumentsRepository.save(supplierDocument);
-  //   return {
-  //     id: savedDocument.id,
-  //     category: savedDocument.category,
-  //     file: {
-  //       id: storedFile.id,
-  //       originalFilename: storedFile.originalFilename,
-  //       mimeType: storedFile.mimeType,
-  //       size: storedFile.size,
-  //       url: this.filesService.getPublicFileUrl(storedFile.storedFilename),
-  //     },
-  //   };
-  // }
-  // // Validate file mime type based on category
-  // private validateMimeTypeForCategory(
-  //   file: Express.Multer.File,
-  //   category: DocumentCategory,
-  // ) {
-  //   const allowedTypes = this.CATEGORY_ALLOWED_MIME_TYPES[category];
-  //   if (!allowedTypes.includes(file.mimetype)) {
-  //     throw new BadRequestException(
-  //       `Invalid file type for ${category}. Allowed: ${allowedTypes.join(', ')}`,
-  //     );
-  //   }
-  // }
-  // // Check if category limit is reached (for categories with limit > 1)
-  // private async checkCategoryLimit(
-  //   supplierId: number,
-  //   category: DocumentCategory,
-  // ) {
-  //   const count = await this.supplierDocumentsRepository.count({
-  //     where: { supplierId, category },
-  //   });
-  //   if (count >= this.CATEGORY_LIMITS[category]) {
-  //     throw new BadRequestException(
-  //       `Maximum ${this.CATEGORY_LIMITS[category]} ${category} files allowed. Please delete an existing file first.`,
-  //     );
-  //   }
-  // }
+  constructor(
+    @InjectRepository(Document)
+    private documentsRepository: Repository<Document>,
+    private readonly filesService: FilesService,
+  ) {}
+  // Number of allowed documents for each category
+  private readonly CATEGORY_LIMITS: Record<DocumentCategory, number> = {
+    [DocumentCategory.LOGO]: 1,
+    [DocumentCategory.COVER_PHOTO]: 1,
+    [DocumentCategory.CATALOG]: 1,
+    [DocumentCategory.GALLERY_PHOTO]: 6,
+  };
+  // Allowed mime types for each category
+  private readonly CATEGORY_ALLOWED_MIME_TYPES: Record<
+    DocumentCategory,
+    string[]
+  > = {
+    [DocumentCategory.LOGO]: ['image/png', 'image/jpeg', 'image/webp'],
+    [DocumentCategory.COVER_PHOTO]: ['image/png', 'image/jpeg', 'image/webp'],
+    [DocumentCategory.CATALOG]: ['application/pdf'],
+    [DocumentCategory.GALLERY_PHOTO]: ['image/png', 'image/jpeg', 'image/webp'],
+  };
+  // Categories that can only be uploaded by suppliers (not restaurants)
+  private readonly SUPPLIER_ONLY_CATEGORIES: DocumentCategory[] = [
+    DocumentCategory.CATALOG,
+    DocumentCategory.GALLERY_PHOTO,
+  ];
+
+  // Upload a document(with category-specific rules)
+  async upload(
+    establishmentId: number,
+    establishmentType: EstablishmentType | null,
+    file: Express.Multer.File,
+    category: DocumentCategory,
+  ): Promise<DocumentResponseDto> {
+    this.validateCategoryForEstablishmentType(category, establishmentType);
+    this.validateMimeTypeForCategory(file, category);
+    await this.checkCategoryLimit(establishmentId, category);
+
+    const storedFile = await this.filesService.create(file);
+    const document = this.documentsRepository.create({
+      establishmentId,
+      fileId: storedFile.id,
+      category,
+    });
+    const savedDocument = await this.documentsRepository.save(document);
+
+    return {
+      id: savedDocument.id,
+      category: savedDocument.category,
+      file: {
+        id: storedFile.id,
+        originalFilename: storedFile.originalFilename,
+        mimeType: storedFile.mimeType,
+        size: storedFile.size,
+        url: this.filesService.getPublicFileUrl(storedFile.storedFilename),
+      },
+    };
+  }
+
+  async findAllByEstablishment(
+    establishmentId: number,
+  ): Promise<GroupedDocumentsResponseDto> {
+    const documents = await this.documentsRepository.find({
+      where: { establishmentId },
+      relations: ['file'],
+      order: { createdAt: 'DESC' },
+    });
+
+    const grouped: GroupedDocumentsResponseDto = {
+      LOGO: [],
+      COVER_PHOTO: [],
+      CATALOG: [],
+      GALLERY_PHOTO: [],
+    };
+
+    for (const doc of documents) {
+      grouped[doc.category].push({
+        id: doc.id,
+        file: {
+          id: doc.file.id,
+          originalFilename: doc.file.originalFilename,
+          mimeType: doc.file.mimeType,
+          size: doc.file.size,
+          url: this.filesService.getPublicFileUrl(doc.file.storedFilename),
+        },
+      });
+    }
+
+    return grouped;
+  }
+
+  async delete(documentId: number, establishmentId: number): Promise<void> {
+    const document = await this.documentsRepository.findOne({
+      where: { id: documentId, establishmentId },
+    });
+
+    if (!document) {
+      throw new NotFoundException(`Document not found`);
+    }
+
+    await this.filesService.delete(document.fileId);
+  }
+
+  // Validate that the category is allowed for the establishment type
+  private validateCategoryForEstablishmentType(
+    category: DocumentCategory,
+    establishmentType: EstablishmentType | null,
+  ) {
+    if (
+      this.SUPPLIER_ONLY_CATEGORIES.includes(category) &&
+      establishmentType !== EstablishmentType.SUPPLIER
+    ) {
+      throw new ForbiddenException(
+        `Category ${category} can only be uploaded by suppliers`,
+      );
+    }
+  }
+
+  // Validate file mime type based on category
+  private validateMimeTypeForCategory(
+    file: Express.Multer.File,
+    category: DocumentCategory,
+  ) {
+    const allowedTypes = this.CATEGORY_ALLOWED_MIME_TYPES[category];
+    if (!allowedTypes.includes(file.mimetype)) {
+      throw new BadRequestException(
+        `Invalid file type for ${category}. Allowed: ${allowedTypes.join(', ')}`,
+      );
+    }
+  }
+
+  // Check if category limit is reached (for categories with limit > 1)
+  private async checkCategoryLimit(
+    establishmentId: number,
+    category: DocumentCategory,
+  ) {
+    const count = await this.documentsRepository.count({
+      where: { establishmentId, category },
+    });
+    if (count >= this.CATEGORY_LIMITS[category]) {
+      throw new BadRequestException(
+        `Maximum ${this.CATEGORY_LIMITS[category]} ${category} files allowed. Please delete an existing file first.`,
+      );
+    }
+  }
 }

--- a/backend/src/documents/dto/create-document.dto.ts
+++ b/backend/src/documents/dto/create-document.dto.ts
@@ -3,7 +3,7 @@ import { DocumentCategory } from '../enums/document.enum';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateDocumentDto {
-  @ApiProperty({ enum: DocumentCategory })
+  @ApiProperty({ enum: DocumentCategory, example: DocumentCategory.CATALOG })
   @IsEnum(DocumentCategory)
   category: DocumentCategory;
 }

--- a/backend/src/documents/dto/grouped-documents-item.dto.ts
+++ b/backend/src/documents/dto/grouped-documents-item.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { FileResponseDto } from '../../files/dto/FileResponse.dto';
+
+export class GroupedDocumentItemDto {
+  @ApiProperty({ example: 5 })
+  id: number;
+
+  @ApiProperty({ type: FileResponseDto })
+  file: FileResponseDto;
+}

--- a/backend/src/documents/dto/grouped-documents-response.dto.ts
+++ b/backend/src/documents/dto/grouped-documents-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GroupedDocumentItemDto } from './grouped-documents-item.dto';
+
+export class GroupedDocumentsResponseDto {
+  @ApiProperty({ type: [GroupedDocumentItemDto] })
+  LOGO: GroupedDocumentItemDto[];
+
+  @ApiProperty({ type: [GroupedDocumentItemDto] })
+  COVER_PHOTO: GroupedDocumentItemDto[];
+
+  @ApiProperty({ type: [GroupedDocumentItemDto] })
+  CATALOG: GroupedDocumentItemDto[];
+
+  @ApiProperty({ type: [GroupedDocumentItemDto] })
+  GALLERY_PHOTO: GroupedDocumentItemDto[];
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -36,8 +36,8 @@ async function bootstrap() {
       .addTag('restaurants', 'Restaurant management and favorites')
       .addTag('suppliers', 'Supplier management and search')
       .addTag(
-        'supplier-documents',
-        'Supplier document management (logo, cover photo, gallery photos, catalog PDF)',
+        'documents',
+        'Establishment document management (logo, cover photo, gallery photos, catalog PDF)',
       )
       .addTag('conversations', 'Messaging system')
       .addTag('reviews', 'Reviews and ratings')


### PR DESCRIPTION
This PR extends the Documents module to support all establishments (restaurants and suppliers) and introduces document listing and deletion.

## Features

- Upload documents for both restaurants and suppliers  
- Category-based validation with supplier-only restrictions  
- GET /documents endpoint returning documents grouped by category  
- DELETE /documents/:id endpoint with ownership validation

## Authentication Refactor

- Refactor JWT strategy to fetch user from database during validation  
- Ensure establishmentId and establishmentType are always up to date in @CurrentUser  
- Simplify JWT payload structure (minimal payload)  

## Documentation
Swagger updates for new endpoints