### PR TITLE
Implement conversation and messaging system – Issue #26

### DIFF
--- a/backend/src/common/guards/establishment.guard.ts
+++ b/backend/src/common/guards/establishment.guard.ts
@@ -1,0 +1,21 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { AuthenticatedUser } from 'src/auth/interfaces/authenticated-user.interface';
+
+@Injectable()
+export class EstablishmentGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context
+      .switchToHttp()
+      .getRequest<Request & { user: AuthenticatedUser }>();
+
+    if (!request.user.establishmentId || !request.user.establishmentType) {
+      throw new ForbiddenException('You must create an establishment first');
+    }
+    return true;
+  }
+}

--- a/backend/src/conversations/conversations.controller.ts
+++ b/backend/src/conversations/conversations.controller.ts
@@ -3,45 +3,102 @@ import {
   Get,
   Post,
   Body,
-  Patch,
   Param,
-  Delete,
+  ParseIntPipe,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ConversationsService } from './conversations.service';
 import { CreateConversationDto } from './dto/create-conversation.dto';
-import { UpdateConversationDto } from './dto/update-conversation.dto';
 import { ApiTags } from '@nestjs/swagger/dist/decorators/api-use-tags.decorator';
+import { ApiBearerAuth } from '@nestjs/swagger';
+import { CurrentUser } from 'src/common/decorators/current-user.decorator';
+import { type AuthenticatedUser } from 'src/auth/interfaces/authenticated-user.interface';
+import { SendMessageDto } from './dto/send-message.dto';
 
 @ApiTags('conversations')
+@ApiBearerAuth()
 @Controller('conversations')
 export class ConversationsController {
   constructor(private readonly conversationsService: ConversationsService) {}
 
+  @Get('unread-count')
+  getUnreadCount(@CurrentUser() user: AuthenticatedUser) {
+    if (!user.establishmentId || !user.establishmentType) {
+      throw new ForbiddenException(
+        'You must create an establishment before checking unread messages',
+      );
+    }
+
+    return this.conversationsService.getTotalUnreadCount(
+      user.establishmentId,
+      user.establishmentType,
+    );
+  }
+
   @Post()
-  create(@Body() createConversationDto: CreateConversationDto) {
-    return this.conversationsService.create(createConversationDto);
+  createConversation(
+    @Body() createConversationDto: CreateConversationDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    if (!user.establishmentId || !user.establishmentType) {
+      throw new ForbiddenException(
+        'You must create an establishment before creating conversations',
+      );
+    }
+    return this.conversationsService.createConversation(
+      user.establishmentId,
+      user.establishmentType,
+      createConversationDto.supplierId,
+    );
+  }
+
+  @Post(':id/messages')
+  sendMessage(
+    @Param('id', ParseIntPipe) conversationId: number,
+    @Body() sendMessageDto: SendMessageDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    if (!user.establishmentId || !user.establishmentType) {
+      throw new ForbiddenException(
+        'You must create an establishment before sending messages',
+      );
+    }
+
+    return this.conversationsService.sendMessage(
+      conversationId,
+      user.establishmentId,
+      user.establishmentType,
+      sendMessageDto.content,
+    );
   }
 
   @Get()
-  findAll() {
-    return this.conversationsService.findAll();
+  getConversations(@CurrentUser() user: AuthenticatedUser) {
+    if (!user.establishmentId || !user.establishmentType) {
+      throw new ForbiddenException(
+        'You must create an establishment before viewing conversations',
+      );
+    }
+    return this.conversationsService.getConversations(
+      user.establishmentId,
+      user.establishmentType,
+    );
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.conversationsService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(
-    @Param('id') id: string,
-    @Body() updateConversationDto: UpdateConversationDto,
+  @Get(':id/messages')
+  getConversationMessages(
+    @Param('id', ParseIntPipe) conversationId: number,
+    @CurrentUser() user: AuthenticatedUser,
   ) {
-    return this.conversationsService.update(+id, updateConversationDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.conversationsService.remove(+id);
+    if (!user.establishmentId || !user.establishmentType) {
+      throw new ForbiddenException(
+        'You must create an establishment before viewing conversations',
+      );
+    }
+    return this.conversationsService.getConversationMessages(
+      conversationId,
+      user.establishmentId,
+      user.establishmentType,
+    );
   }
 }

--- a/backend/src/conversations/conversations.controller.ts
+++ b/backend/src/conversations/conversations.controller.ts
@@ -5,100 +5,112 @@ import {
   Body,
   Param,
   ParseIntPipe,
-  ForbiddenException,
+  UseGuards,
 } from '@nestjs/common';
 import { ConversationsService } from './conversations.service';
 import { CreateConversationDto } from './dto/create-conversation.dto';
-import { ApiTags } from '@nestjs/swagger/dist/decorators/api-use-tags.decorator';
-import { ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { type AuthenticatedUser } from 'src/auth/interfaces/authenticated-user.interface';
 import { SendMessageDto } from './dto/send-message.dto';
+import { EstablishmentGuard } from 'src/common/guards/establishment.guard';
+import { Conversation } from './entities/conversation.entity';
+import { Message } from './entities/message.entity';
+import { ConversationResponseDto } from './dto/conversation-response.dto';
+import { UnreadCountResponseDto } from './dto/unread-count-response.dto';
 
 @ApiTags('conversations')
 @ApiBearerAuth()
+@UseGuards(EstablishmentGuard)
 @Controller('conversations')
 export class ConversationsController {
   constructor(private readonly conversationsService: ConversationsService) {}
 
-  @Get('unread-count')
-  getUnreadCount(@CurrentUser() user: AuthenticatedUser) {
-    if (!user.establishmentId || !user.establishmentType) {
-      throw new ForbiddenException(
-        'You must create an establishment before checking unread messages',
-      );
-    }
-
-    return this.conversationsService.getTotalUnreadCount(
-      user.establishmentId,
-      user.establishmentType,
-    );
-  }
-
   @Post()
+  @ApiOperation({ summary: 'Create a conversation with a supplier' })
+  @ApiCreatedResponse({ type: Conversation })
+  @ApiForbiddenResponse({
+    description: 'Only restaurants can create conversations',
+  })
+  @ApiNotFoundResponse({ description: 'Supplier not found' })
   createConversation(
     @Body() createConversationDto: CreateConversationDto,
     @CurrentUser() user: AuthenticatedUser,
-  ) {
-    if (!user.establishmentId || !user.establishmentType) {
-      throw new ForbiddenException(
-        'You must create an establishment before creating conversations',
-      );
-    }
+  ): Promise<Conversation> {
     return this.conversationsService.createConversation(
-      user.establishmentId,
-      user.establishmentType,
+      user.establishmentId!,
+      user.establishmentType!,
       createConversationDto.supplierId,
     );
   }
 
   @Post(':id/messages')
+  @ApiOperation({ summary: 'Send a message in a conversation' })
+  @ApiCreatedResponse({ type: Message })
+  @ApiForbiddenResponse({
+    description: 'Not a participant of this conversation',
+  })
+  @ApiNotFoundResponse({ description: 'Conversation not found' })
   sendMessage(
     @Param('id', ParseIntPipe) conversationId: number,
     @Body() sendMessageDto: SendMessageDto,
     @CurrentUser() user: AuthenticatedUser,
-  ) {
-    if (!user.establishmentId || !user.establishmentType) {
-      throw new ForbiddenException(
-        'You must create an establishment before sending messages',
-      );
-    }
-
+  ): Promise<Message> {
     return this.conversationsService.sendMessage(
       conversationId,
-      user.establishmentId,
-      user.establishmentType,
+      user.establishmentId!,
+      user.establishmentType!,
       sendMessageDto.content,
     );
   }
 
   @Get()
-  getConversations(@CurrentUser() user: AuthenticatedUser) {
-    if (!user.establishmentId || !user.establishmentType) {
-      throw new ForbiddenException(
-        'You must create an establishment before viewing conversations',
-      );
-    }
+  @ApiOperation({ summary: 'Get all conversations' })
+  @ApiOkResponse({ type: [ConversationResponseDto] })
+  getConversations(
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<ConversationResponseDto[]> {
     return this.conversationsService.getConversations(
-      user.establishmentId,
-      user.establishmentType,
+      user.establishmentId!,
+      user.establishmentType!,
+    );
+  }
+
+  @Get('unread-count')
+  @ApiOperation({ summary: 'Get total unread messages count' })
+  @ApiOkResponse({ type: UnreadCountResponseDto })
+  getUnreadCount(
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<UnreadCountResponseDto> {
+    return this.conversationsService.getTotalUnreadCount(
+      user.establishmentId!,
+      user.establishmentType!,
     );
   }
 
   @Get(':id/messages')
+  @ApiOperation({ summary: 'Get messages of a conversation' })
+  @ApiOkResponse({ type: [Message] })
+  @ApiForbiddenResponse({
+    description: 'Not a participant of this conversation',
+  })
+  @ApiNotFoundResponse({ description: 'Conversation not found' })
   getConversationMessages(
     @Param('id', ParseIntPipe) conversationId: number,
     @CurrentUser() user: AuthenticatedUser,
-  ) {
-    if (!user.establishmentId || !user.establishmentType) {
-      throw new ForbiddenException(
-        'You must create an establishment before viewing conversations',
-      );
-    }
+  ): Promise<Message[]> {
     return this.conversationsService.getConversationMessages(
       conversationId,
-      user.establishmentId,
-      user.establishmentType,
+      user.establishmentId!,
+      user.establishmentType!,
     );
   }
 }

--- a/backend/src/conversations/conversations.module.ts
+++ b/backend/src/conversations/conversations.module.ts
@@ -4,9 +4,10 @@ import { ConversationsController } from './conversations.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Conversation } from './entities/conversation.entity';
 import { Message } from './entities/message.entity';
+import { Establishment } from 'src/establishments/entities/establishment.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Conversation, Message])],
+  imports: [TypeOrmModule.forFeature([Conversation, Message, Establishment])],
   controllers: [ConversationsController],
   providers: [ConversationsService],
 })

--- a/backend/src/conversations/conversations.service.ts
+++ b/backend/src/conversations/conversations.service.ts
@@ -10,6 +10,7 @@ import { Repository } from 'typeorm';
 import { Establishment } from '../establishments/entities/establishment.entity';
 import { EstablishmentType } from 'src/establishments/enums/establishment-type.enum';
 import { ConversationResponseDto } from './dto/conversation-response.dto';
+import { UnreadCountResponseDto } from './dto/unread-count-response.dto';
 
 @Injectable()
 export class ConversationsService {
@@ -70,7 +71,10 @@ export class ConversationsService {
       (establishmentType === EstablishmentType.SUPPLIER &&
         conversation.supplierId === establishmentId);
 
-    if (!isParticipant) throw new ForbiddenException();
+    if (!isParticipant)
+      throw new ForbiddenException(
+        'You are not a participant of this conversation',
+      );
 
     const message = this.messagesRepository.create({
       conversationId,
@@ -153,7 +157,7 @@ export class ConversationsService {
       where: { id: conversationId },
     });
 
-    if (!conversation) throw new NotFoundException();
+    if (!conversation) throw new NotFoundException('Conversation not found');
 
     const isParticipant =
       (establishmentType === EstablishmentType.RESTAURANT &&
@@ -161,7 +165,10 @@ export class ConversationsService {
       (establishmentType === EstablishmentType.SUPPLIER &&
         conversation.supplierId === establishmentId);
 
-    if (!isParticipant) throw new ForbiddenException();
+    if (!isParticipant)
+      throw new ForbiddenException(
+        'You are not a participant of this conversation',
+      );
 
     await this.messagesRepository.update(
       {
@@ -184,7 +191,7 @@ export class ConversationsService {
   async getTotalUnreadCount(
     establishmentId: number,
     establishmentType: EstablishmentType,
-  ) {
+  ): Promise<UnreadCountResponseDto> {
     const isRestaurant = establishmentType === EstablishmentType.RESTAURANT;
     const queryBuilder = this.messagesRepository
       .createQueryBuilder('message')

--- a/backend/src/conversations/conversations.service.ts
+++ b/backend/src/conversations/conversations.service.ts
@@ -1,26 +1,204 @@
-import { Injectable } from '@nestjs/common';
-import { CreateConversationDto } from './dto/create-conversation.dto';
-import { UpdateConversationDto } from './dto/update-conversation.dto';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Conversation } from './entities/conversation.entity';
+import { Message } from './entities/message.entity';
+import { Repository } from 'typeorm';
+import { Establishment } from '../establishments/entities/establishment.entity';
+import { EstablishmentType } from 'src/establishments/enums/establishment-type.enum';
+import { ConversationResponseDto } from './dto/conversation-response.dto';
 
 @Injectable()
 export class ConversationsService {
-  create(createConversationDto: CreateConversationDto) {
-    return `This action adds a new conversation ${JSON.stringify(createConversationDto)}`;
+  constructor(
+    @InjectRepository(Conversation)
+    private conversationsRepository: Repository<Conversation>,
+    @InjectRepository(Message) private messagesRepository: Repository<Message>,
+    @InjectRepository(Establishment)
+    private establishmentsRepository: Repository<Establishment>,
+  ) {}
+
+  async createConversation(
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+    supplierId: number,
+  ): Promise<Conversation> {
+    if (establishmentType !== EstablishmentType.RESTAURANT) {
+      throw new ForbiddenException('Only restaurants can create conversations');
+    }
+
+    const supplier = await this.establishmentsRepository.findOne({
+      where: { id: supplierId, type: EstablishmentType.SUPPLIER },
+    });
+
+    if (!supplier) {
+      throw new NotFoundException('Supplier not found');
+    }
+
+    const existing = await this.conversationsRepository.findOne({
+      where: { restaurantId: establishmentId, supplierId },
+    });
+
+    if (existing) return existing;
+
+    const conversation = this.conversationsRepository.create({
+      restaurantId: establishmentId,
+      supplierId,
+    });
+
+    return this.conversationsRepository.save(conversation);
   }
 
-  findAll() {
-    return `This action returns all conversations`;
+  async sendMessage(
+    conversationId: number,
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+    content: string,
+  ): Promise<Message> {
+    const conversation = await this.conversationsRepository.findOne({
+      where: { id: conversationId },
+    });
+
+    if (!conversation) throw new NotFoundException('Conversation not found');
+
+    const isParticipant =
+      (establishmentType === EstablishmentType.RESTAURANT &&
+        conversation.restaurantId === establishmentId) ||
+      (establishmentType === EstablishmentType.SUPPLIER &&
+        conversation.supplierId === establishmentId);
+
+    if (!isParticipant) throw new ForbiddenException();
+
+    const message = this.messagesRepository.create({
+      conversationId,
+      content,
+      senderType: establishmentType,
+      isReadByRecipient: false,
+    });
+
+    await this.messagesRepository.save(message);
+
+    await this.conversationsRepository.update(conversationId, {
+      lastMessageAt: new Date(),
+    });
+
+    return message;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} conversation`;
+  async getConversations(
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+  ): Promise<ConversationResponseDto[]> {
+    const otherParticipantType =
+      establishmentType === EstablishmentType.RESTAURANT
+        ? EstablishmentType.SUPPLIER
+        : EstablishmentType.RESTAURANT;
+
+    const conversations = await this.conversationsRepository.find({
+      where:
+        establishmentType === EstablishmentType.RESTAURANT
+          ? { restaurantId: establishmentId }
+          : { supplierId: establishmentId },
+      relations: [otherParticipantType.toLowerCase()],
+      order: { lastMessageAt: 'DESC' },
+    });
+
+    if (conversations.length === 0) return [];
+
+    const conversationIds = conversations.map((c) => c.id);
+
+    const unreadCounts: { conversationId: number; count: string }[] =
+      await this.messagesRepository
+        .createQueryBuilder('message')
+        .select('message.conversationId', 'conversationId')
+        .addSelect('COUNT(*)', 'count')
+        .where('message.conversationId IN (:...ids)', { ids: conversationIds })
+        .andWhere('message.isReadByRecipient = false')
+        .andWhere('message.senderType = :type', { type: otherParticipantType })
+        .groupBy('message.conversationId')
+        .getRawMany();
+
+    const unreadCountMap: Record<number, number> = {};
+    for (const row of unreadCounts) {
+      unreadCountMap[row.conversationId] = parseInt(row.count);
+    }
+
+    return conversations.map((conversation) => {
+      const otherParticipant =
+        otherParticipantType === EstablishmentType.RESTAURANT
+          ? conversation.restaurant
+          : conversation.supplier;
+
+      return {
+        id: conversation.id,
+        lastMessageAt: conversation.lastMessageAt as Date,
+        unreadCount: unreadCountMap[conversation.id] ?? 0,
+        otherParticipant: {
+          id: otherParticipant.id,
+          name: otherParticipant.tradeName ?? otherParticipant.legalName,
+        },
+      };
+    });
   }
 
-  update(id: number, updateConversationDto: UpdateConversationDto) {
-    return `This action updates a #${id} conversation ${JSON.stringify(updateConversationDto)}`;
+  async getConversationMessages(
+    conversationId: number,
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+  ): Promise<Message[]> {
+    const conversation = await this.conversationsRepository.findOne({
+      where: { id: conversationId },
+    });
+
+    if (!conversation) throw new NotFoundException();
+
+    const isParticipant =
+      (establishmentType === EstablishmentType.RESTAURANT &&
+        conversation.restaurantId === establishmentId) ||
+      (establishmentType === EstablishmentType.SUPPLIER &&
+        conversation.supplierId === establishmentId);
+
+    if (!isParticipant) throw new ForbiddenException();
+
+    await this.messagesRepository.update(
+      {
+        conversationId,
+        isReadByRecipient: false,
+        senderType:
+          establishmentType === EstablishmentType.RESTAURANT
+            ? EstablishmentType.SUPPLIER
+            : EstablishmentType.RESTAURANT,
+      },
+      { isReadByRecipient: true },
+    );
+
+    return this.messagesRepository.find({
+      where: { conversationId },
+      order: { sentAt: 'ASC' },
+    });
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} conversation`;
+  async getTotalUnreadCount(
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+  ) {
+    const isRestaurant = establishmentType === EstablishmentType.RESTAURANT;
+    const queryBuilder = this.messagesRepository
+      .createQueryBuilder('message')
+      .innerJoin('message.conversation', 'conversation')
+      .where('message.isReadByRecipient = false')
+      .andWhere(
+        isRestaurant
+          ? 'conversation.restaurantId = :id'
+          : 'conversation.supplierId = :id',
+        { id: establishmentId },
+      )
+      .andWhere('message.senderType != :type', { type: establishmentType });
+
+    const count = await queryBuilder.getCount();
+    return { count };
   }
 }

--- a/backend/src/conversations/dto/conversation-response.dto.ts
+++ b/backend/src/conversations/dto/conversation-response.dto.ts
@@ -1,16 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class ConversationResponseDto {
-  @ApiProperty()
+  @ApiProperty({ example: 1 })
   id: number;
 
-  @ApiProperty({ nullable: true })
+  @ApiProperty({ example: '2026-02-22T13:49:30.364Z', nullable: true })
   lastMessageAt: Date | null;
 
-  @ApiProperty()
+  @ApiProperty({ example: 3 })
   unreadCount: number;
 
-  @ApiProperty()
+  @ApiProperty({
+    example: { id: 5, name: 'Martin Bio' },
+  })
   otherParticipant: {
     id: number;
     name: string;

--- a/backend/src/conversations/dto/conversation-response.dto.ts
+++ b/backend/src/conversations/dto/conversation-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ConversationResponseDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty({ nullable: true })
+  lastMessageAt: Date | null;
+
+  @ApiProperty()
+  unreadCount: number;
+
+  @ApiProperty()
+  otherParticipant: {
+    id: number;
+    name: string;
+  };
+}

--- a/backend/src/conversations/dto/create-conversation.dto.ts
+++ b/backend/src/conversations/dto/create-conversation.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsPositive } from 'class-validator';
 
 export class CreateConversationDto {
-  @ApiProperty()
+  @ApiProperty({ example: 3 })
   @IsInt()
   @IsPositive()
   supplierId: number;

--- a/backend/src/conversations/dto/create-conversation.dto.ts
+++ b/backend/src/conversations/dto/create-conversation.dto.ts
@@ -1,1 +1,9 @@
-export class CreateConversationDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsPositive } from 'class-validator';
+
+export class CreateConversationDto {
+  @ApiProperty()
+  @IsInt()
+  @IsPositive()
+  supplierId: number;
+}

--- a/backend/src/conversations/dto/send-message.dto.ts
+++ b/backend/src/conversations/dto/send-message.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class SendMessageDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(5000)
+  content: string;
+}

--- a/backend/src/conversations/dto/send-message.dto.ts
+++ b/backend/src/conversations/dto/send-message.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class SendMessageDto {
-  @ApiProperty()
+  @ApiProperty({ example: 'Quels sont vos délais de livraison ?' })
   @IsString()
   @IsNotEmpty()
   @MaxLength(5000)

--- a/backend/src/conversations/dto/unread-count-response.dto.ts
+++ b/backend/src/conversations/dto/unread-count-response.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UnreadCountResponseDto {
+  @ApiProperty()
+  count: number;
+}

--- a/backend/src/conversations/dto/unread-count-response.dto.ts
+++ b/backend/src/conversations/dto/unread-count-response.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UnreadCountResponseDto {
-  @ApiProperty()
+  @ApiProperty({ example: 3 })
   count: number;
 }

--- a/backend/src/conversations/dto/update-conversation.dto.ts
+++ b/backend/src/conversations/dto/update-conversation.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateConversationDto } from './create-conversation.dto';
-
-export class UpdateConversationDto extends PartialType(CreateConversationDto) {}

--- a/backend/src/conversations/entities/conversation.entity.ts
+++ b/backend/src/conversations/entities/conversation.entity.ts
@@ -11,6 +11,7 @@ import {
 } from 'typeorm';
 import { Message } from './message.entity';
 import { Establishment } from '../../establishments/entities/establishment.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Entity('conversation')
 @Unique('uq_conversation_restaurant_supplier', ['restaurantId', 'supplierId'])
@@ -18,18 +19,23 @@ import { Establishment } from '../../establishments/entities/establishment.entit
 @Index(['restaurantId'])
 @Index(['supplierId'])
 export class Conversation {
+  @ApiProperty({ example: 1 })
   @PrimaryGeneratedColumn()
   id: number;
 
+  @ApiProperty({ example: 3 })
   @Column({ name: 'restaurant_id', type: 'int' })
   restaurantId: number;
 
+  @ApiProperty({ example: 5 })
   @Column({ name: 'supplier_id', type: 'int' })
   supplierId: number;
 
+  @ApiProperty({ example: '2026-02-22T13:49:30.000Z' })
   @CreateDateColumn({ name: 'created_at', type: 'datetime' })
   createdAt: Date;
 
+  @ApiProperty({ example: '2026-02-26T20:15:25.000Z', nullable: true })
   @Column({ name: 'last_message_at', type: 'datetime', nullable: true })
   lastMessageAt: Date | null;
 

--- a/backend/src/conversations/entities/message.entity.ts
+++ b/backend/src/conversations/entities/message.entity.ts
@@ -12,27 +12,37 @@ import {
 import { Conversation } from './conversation.entity';
 import { StoredFile } from '../../files/entities/stored-file.entity';
 import { EstablishmentType } from 'src/establishments/enums/establishment-type.enum';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Entity('message')
 @Index('idx_message_is_read_by_recipient', ['isReadByRecipient'])
 @Index('idx_message_sent_at', ['sentAt'])
 @Index(['conversationId'])
 export class Message {
+  @ApiProperty({ example: 1 })
   @PrimaryGeneratedColumn()
   id: number;
 
+  @ApiProperty({ example: 2 })
   @Column({ name: 'conversation_id', type: 'int' })
   conversationId: number;
 
+  @ApiProperty({
+    enum: EstablishmentType,
+    example: EstablishmentType.RESTAURANT,
+  })
   @Column({ name: 'sender_type', type: 'enum', enum: EstablishmentType })
   senderType: EstablishmentType;
 
+  @ApiProperty({ example: 'Quels sont vos délais de livraison ?' })
   @Column({ type: 'text' })
   content: string;
 
+  @ApiProperty({ example: '2026-02-26T20:15:25.000Z' })
   @CreateDateColumn({ name: 'sent_at', type: 'datetime' })
   sentAt: Date;
 
+  @ApiProperty({ example: false })
   @Column({ name: 'is_read_by_recipient', type: 'boolean', default: false })
   isReadByRecipient: boolean;
 

--- a/backend/src/conversations/entities/message.entity.ts
+++ b/backend/src/conversations/entities/message.entity.ts
@@ -9,12 +9,12 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { SenderType } from '../enums/sender-type.enum';
 import { Conversation } from './conversation.entity';
 import { StoredFile } from '../../files/entities/stored-file.entity';
+import { EstablishmentType } from 'src/establishments/enums/establishment-type.enum';
 
 @Entity('message')
-@Index('idx_message_is_read', ['isRead'])
+@Index('idx_message_is_read_by_recipient', ['isReadByRecipient'])
 @Index('idx_message_sent_at', ['sentAt'])
 @Index(['conversationId'])
 export class Message {
@@ -24,8 +24,8 @@ export class Message {
   @Column({ name: 'conversation_id', type: 'int' })
   conversationId: number;
 
-  @Column({ name: 'sender_type', type: 'enum', enum: SenderType })
-  senderType: SenderType;
+  @Column({ name: 'sender_type', type: 'enum', enum: EstablishmentType })
+  senderType: EstablishmentType;
 
   @Column({ type: 'text' })
   content: string;
@@ -33,8 +33,8 @@ export class Message {
   @CreateDateColumn({ name: 'sent_at', type: 'datetime' })
   sentAt: Date;
 
-  @Column({ name: 'is_read', type: 'boolean', default: false })
-  isRead: boolean;
+  @Column({ name: 'is_read_by_recipient', type: 'boolean', default: false })
+  isReadByRecipient: boolean;
 
   // Relations
   @ManyToOne(() => Conversation, (conversation) => conversation.messages, {

--- a/backend/src/conversations/enums/sender-type.enum.ts
+++ b/backend/src/conversations/enums/sender-type.enum.ts
@@ -1,4 +1,0 @@
-export enum SenderType {
-  RESTAURANT = 'RESTAURANT',
-  SUPPLIER = 'SUPPLIER',
-}

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -2,7 +2,6 @@ import {
   Body,
   Controller,
   Delete,
-  ForbiddenException,
   Get,
   HttpCode,
   HttpStatus,
@@ -11,6 +10,7 @@ import {
   ParseIntPipe,
   Post,
   UploadedFile,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
@@ -34,9 +34,11 @@ import { DocumentCategory } from '../documents/enums/document.enum';
 import { DocumentResponseDto } from '../documents/dto/document-response.dto';
 import { DocumentsService } from './documents.service';
 import { GroupedDocumentsResponseDto } from './dto/grouped-documents-response.dto';
+import { EstablishmentGuard } from 'src/common/guards/establishment.guard';
 
 @ApiTags('documents')
 @ApiBearerAuth()
+@UseGuards(EstablishmentGuard)
 @Controller('documents')
 export class DocumentsController {
   constructor(private readonly documentsService: DocumentsService) {}
@@ -84,14 +86,8 @@ export class DocumentsController {
     file: Express.Multer.File,
     @Body() dto: CreateDocumentDto,
   ) {
-    if (user.establishmentId === null) {
-      throw new ForbiddenException(
-        'You must create an establishment before managing documents',
-      );
-    }
-
     return this.documentsService.upload(
-      user.establishmentId,
+      user.establishmentId!,
       user.establishmentType,
       file,
       dto.category,
@@ -109,13 +105,7 @@ export class DocumentsController {
   async findAll(
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<GroupedDocumentsResponseDto> {
-    if (user.establishmentId === null) {
-      throw new ForbiddenException(
-        'You must create an establishment before managing documents',
-      );
-    }
-
-    return this.documentsService.findAllByEstablishment(user.establishmentId);
+    return this.documentsService.findAllByEstablishment(user.establishmentId!);
   }
 
   @Delete(':id')
@@ -129,12 +119,6 @@ export class DocumentsController {
     @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseIntPipe) documentId: number,
   ) {
-    if (user.establishmentId === null) {
-      throw new ForbiddenException(
-        'You must create an establishment before managing documents',
-      );
-    }
-
-    return this.documentsService.delete(documentId, user.establishmentId);
+    return this.documentsService.delete(documentId, user.establishmentId!);
   }
 }

--- a/backend/src/establishments/establishments.controller.ts
+++ b/backend/src/establishments/establishments.controller.ts
@@ -11,10 +11,11 @@ import {
 import { EstablishmentsService } from './establishments.service';
 import { CreateEstablishmentDto } from './dto/create-establishment.dto';
 import { UpdateEstablishmentDto } from './dto/update-establishment.dto';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { AuthenticatedUser } from 'src/auth/interfaces/authenticated-user.interface';
 
 @ApiTags('establishments')
+@ApiBearerAuth()
 @Controller('establishments')
 export class EstablishmentsController {
   constructor(private readonly establishmentsService: EstablishmentsService) {}

--- a/backend/src/favorites/favorites.controller.ts
+++ b/backend/src/favorites/favorites.controller.ts
@@ -1,7 +1,10 @@
 import { Controller, Get, Post, Body, Param, Delete } from '@nestjs/common';
 import { FavoritesService } from './favorites.service';
 import { CreateFavoriteDto } from './dto/create-favorite.dto';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('favorites')
+@ApiBearerAuth()
 @Controller('establishments')
 export class FavoritesController {
   constructor(private readonly favoritesService: FavoritesService) {}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -33,12 +33,13 @@ async function bootstrap() {
       .addBearerAuth()
       .addTag('auth', 'Authentication and user management')
       .addTag('users', 'User operations')
-      .addTag('restaurants', 'Restaurant management and favorites')
+      .addTag('establishments', 'Establishment management')
       .addTag('suppliers', 'Supplier management and search')
       .addTag(
         'documents',
         'Establishment document management (logo, cover photo, gallery photos, catalog PDF)',
       )
+      .addTag('favorites', 'Restaurant favorites management')
       .addTag('conversations', 'Messaging system')
       .addTag('reviews', 'Reviews and ratings')
       .build(),

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -35,7 +35,7 @@ export class UsersController {
     type: User,
   })
   @ApiNotFoundResponse({ description: 'User not found' })
-  async getProfile(@CurrentUser() user: AuthenticatedUser): Promise<User> {
+  getProfile(@CurrentUser() user: AuthenticatedUser): Promise<User> {
     return this.usersService.findOne(user.id);
   }
 
@@ -46,7 +46,7 @@ export class UsersController {
     type: User,
   })
   @ApiNotFoundResponse({ description: 'User not found' })
-  async updateProfile(
+  updateProfile(
     @CurrentUser() user: AuthenticatedUser,
     @Body() updateUserDto: UpdateUserDto,
   ): Promise<User> {
@@ -58,7 +58,7 @@ export class UsersController {
   @ApiOperation({ summary: 'Delete current user account' })
   @ApiNoContentResponse({ description: 'User account deleted' })
   @ApiNotFoundResponse({ description: 'User not found' })
-  async deleteAccount(@CurrentUser() user: AuthenticatedUser): Promise<void> {
+  deleteAccount(@CurrentUser() user: AuthenticatedUser): Promise<void> {
     return this.usersService.remove(user.id);
   }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -10,7 +10,7 @@ import { User } from './entities/user.entity';
 import { Repository } from 'typeorm';
 import * as bcrypt from 'bcryptjs';
 import { ConfigService } from '@nestjs/config';
-import { FindOneOptions } from 'typeorm'
+import { FindOneOptions } from 'typeorm';
 
 @Injectable()
 export class UsersService {
@@ -37,7 +37,7 @@ export class UsersService {
   async findOne(id: number, options?: FindOneOptions<User>): Promise<User> {
     const user = await this.usersRepository.findOne({
       ...(options || {}),
-      where: { id }
+      where: { id },
     });
     if (!user) {
       throw new NotFoundException(`User with ID ${id} not found`);


### PR DESCRIPTION
This PR implements the full conversation and messaging module between restaurants and suppliers.

### Features
- `POST /conversations` — create a conversation (restaurants only)
- `POST /conversations/:id/messages` — send a message in a conversation
- `GET /conversations` — list all conversations with unread count per conversation
- `GET /conversations/:id/messages` — get messages of a conversation (marks them as read)
- `GET /conversations/unread-count` — get total unread messages count

### Authorization
- `EstablishmentGuard` — centralized guard ensuring the user has an active establishment before accessing any conversation route
- Participant validation on all conversation routes

### Documentation
- Swagger documentation for all endpoints
- `@ApiProperty` with examples on all entities and DTOs