### PR TITLE
Implement private message attachments in conversations module - Issue #28

### DIFF
--- a/backend/src/config/multer.config.ts
+++ b/backend/src/config/multer.config.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'crypto';
-import { diskStorage } from 'multer';
+import { diskStorage, FileFilterCallback } from 'multer';
 import { extname } from 'path';
 import { PRIVATE_UPLOAD_PATH, PUBLIC_UPLOAD_PATH } from './storage.config';
+import { BadRequestException } from '@nestjs/common';
 
 const generateFileName = (
   _req: Express.Request,
@@ -12,6 +13,28 @@ const generateFileName = (
   cb(null, uniqueName);
 };
 
+const allowedMimeTypes = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'application/pdf',
+];
+
+const fileFilter = (
+  _req: Express.Request,
+  file: Express.Multer.File,
+  cb: FileFilterCallback,
+) => {
+  if (!allowedMimeTypes.includes(file.mimetype)) {
+    return cb(
+      new BadRequestException(
+        `Invalid file type. Allowed: ${allowedMimeTypes.join(', ')}`,
+      ),
+    );
+  }
+  cb(null, true);
+};
+
 export const multerPublicOptions = {
   storage: diskStorage({
     destination: PUBLIC_UPLOAD_PATH,
@@ -20,6 +43,7 @@ export const multerPublicOptions = {
   limits: {
     fileSize: 20 * 1024 * 1024,
   },
+  fileFilter,
 };
 
 export const multerPrivateOptions = {
@@ -30,4 +54,5 @@ export const multerPrivateOptions = {
   limits: {
     fileSize: 10 * 1024 * 1024,
   },
+  fileFilter,
 };

--- a/backend/src/conversations/conversations.controller.ts
+++ b/backend/src/conversations/conversations.controller.ts
@@ -18,14 +18,14 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { CurrentUser } from 'src/common/decorators/current-user.decorator';
-import { type AuthenticatedUser } from 'src/auth/interfaces/authenticated-user.interface';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
 import { SendMessageDto } from './dto/send-message.dto';
-import { EstablishmentGuard } from 'src/common/guards/establishment.guard';
+import { EstablishmentGuard } from '../common/guards/establishment.guard';
 import { Conversation } from './entities/conversation.entity';
-import { Message } from './entities/message.entity';
 import { ConversationResponseDto } from './dto/conversation-response.dto';
 import { UnreadCountResponseDto } from './dto/unread-count-response.dto';
+import { MessageResponseDto } from './dto/message-response.dto';
 
 @ApiTags('conversations')
 @ApiBearerAuth()
@@ -54,7 +54,7 @@ export class ConversationsController {
 
   @Post(':id/messages')
   @ApiOperation({ summary: 'Send a message in a conversation' })
-  @ApiCreatedResponse({ type: Message })
+  @ApiCreatedResponse({ type: MessageResponseDto })
   @ApiForbiddenResponse({
     description: 'Not a participant of this conversation',
   })
@@ -63,7 +63,7 @@ export class ConversationsController {
     @Param('id', ParseIntPipe) conversationId: number,
     @Body() sendMessageDto: SendMessageDto,
     @CurrentUser() user: AuthenticatedUser,
-  ): Promise<Message> {
+  ): Promise<MessageResponseDto> {
     return this.conversationsService.sendMessage(
       conversationId,
       user.establishmentId!,
@@ -98,7 +98,7 @@ export class ConversationsController {
 
   @Get(':id/messages')
   @ApiOperation({ summary: 'Get messages of a conversation' })
-  @ApiOkResponse({ type: [Message] })
+  @ApiOkResponse({ type: [MessageResponseDto] })
   @ApiForbiddenResponse({
     description: 'Not a participant of this conversation',
   })
@@ -106,7 +106,7 @@ export class ConversationsController {
   getConversationMessages(
     @Param('id', ParseIntPipe) conversationId: number,
     @CurrentUser() user: AuthenticatedUser,
-  ): Promise<Message[]> {
+  ): Promise<MessageResponseDto[]> {
     return this.conversationsService.getConversationMessages(
       conversationId,
       user.establishmentId!,

--- a/backend/src/conversations/conversations.module.ts
+++ b/backend/src/conversations/conversations.module.ts
@@ -4,11 +4,16 @@ import { ConversationsController } from './conversations.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Conversation } from './entities/conversation.entity';
 import { Message } from './entities/message.entity';
-import { Establishment } from 'src/establishments/entities/establishment.entity';
+import { Establishment } from '../establishments/entities/establishment.entity';
+import { FilesModule } from '../files/files.module';
+import { MessageAttachmentsController } from './message-attachments.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Conversation, Message, Establishment])],
-  controllers: [ConversationsController],
+  imports: [
+    FilesModule,
+    TypeOrmModule.forFeature([Conversation, Message, Establishment]),
+  ],
+  controllers: [ConversationsController, MessageAttachmentsController],
   providers: [ConversationsService],
 })
 export class ConversationsModule {}

--- a/backend/src/conversations/conversations.service.ts
+++ b/backend/src/conversations/conversations.service.ts
@@ -28,6 +28,7 @@ export class ConversationsService {
     private readonly filesService: FilesService,
   ) {}
 
+  // Creates a new conversation or returns existing one if already exists
   async createConversation(
     establishmentId: number,
     establishmentType: EstablishmentType,
@@ -153,6 +154,7 @@ export class ConversationsService {
     });
   }
 
+  // Marks unread messages from the other participant as read and returns all messages with attachments
   async getConversationMessages(
     conversationId: number,
     establishmentId: number,
@@ -258,6 +260,7 @@ export class ConversationsService {
     };
   }
 
+  // Streams private file after verifying conversation participation
   async streamAttachment(
     messageId: number,
     fileId: number,
@@ -288,6 +291,7 @@ export class ConversationsService {
     });
   }
 
+  // Ensures the current establishment is a participant of the conversation
   private checkIsParticipant(
     conversation: Conversation,
     establishmentId: number,

--- a/backend/src/conversations/conversations.service.ts
+++ b/backend/src/conversations/conversations.service.ts
@@ -2,6 +2,7 @@ import {
   ForbiddenException,
   Injectable,
   NotFoundException,
+  StreamableFile,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Conversation } from './entities/conversation.entity';
@@ -11,6 +12,10 @@ import { Establishment } from '../establishments/entities/establishment.entity';
 import { EstablishmentType } from 'src/establishments/enums/establishment-type.enum';
 import { ConversationResponseDto } from './dto/conversation-response.dto';
 import { UnreadCountResponseDto } from './dto/unread-count-response.dto';
+import { FilesService } from '../files/files.service';
+import { MessageAttachmentResponseDto } from './dto/message-attachments-response.dto';
+import { createReadStream } from 'node:fs';
+import { MessageResponseDto } from './dto/message-response.dto';
 
 @Injectable()
 export class ConversationsService {
@@ -20,6 +25,7 @@ export class ConversationsService {
     @InjectRepository(Message) private messagesRepository: Repository<Message>,
     @InjectRepository(Establishment)
     private establishmentsRepository: Repository<Establishment>,
+    private readonly filesService: FilesService,
   ) {}
 
   async createConversation(
@@ -58,23 +64,14 @@ export class ConversationsService {
     establishmentId: number,
     establishmentType: EstablishmentType,
     content: string,
-  ): Promise<Message> {
+  ): Promise<MessageResponseDto> {
     const conversation = await this.conversationsRepository.findOne({
       where: { id: conversationId },
     });
 
     if (!conversation) throw new NotFoundException('Conversation not found');
 
-    const isParticipant =
-      (establishmentType === EstablishmentType.RESTAURANT &&
-        conversation.restaurantId === establishmentId) ||
-      (establishmentType === EstablishmentType.SUPPLIER &&
-        conversation.supplierId === establishmentId);
-
-    if (!isParticipant)
-      throw new ForbiddenException(
-        'You are not a participant of this conversation',
-      );
+    this.checkIsParticipant(conversation, establishmentId, establishmentType);
 
     const message = this.messagesRepository.create({
       conversationId,
@@ -89,7 +86,15 @@ export class ConversationsService {
       lastMessageAt: new Date(),
     });
 
-    return message;
+    return {
+      id: message.id,
+      conversationId: message.conversationId,
+      senderType: message.senderType,
+      content: message.content,
+      sentAt: message.sentAt,
+      isReadByRecipient: message.isReadByRecipient,
+      attachments: [],
+    };
   }
 
   async getConversations(
@@ -152,23 +157,14 @@ export class ConversationsService {
     conversationId: number,
     establishmentId: number,
     establishmentType: EstablishmentType,
-  ): Promise<Message[]> {
+  ): Promise<MessageResponseDto[]> {
     const conversation = await this.conversationsRepository.findOne({
       where: { id: conversationId },
     });
 
     if (!conversation) throw new NotFoundException('Conversation not found');
 
-    const isParticipant =
-      (establishmentType === EstablishmentType.RESTAURANT &&
-        conversation.restaurantId === establishmentId) ||
-      (establishmentType === EstablishmentType.SUPPLIER &&
-        conversation.supplierId === establishmentId);
-
-    if (!isParticipant)
-      throw new ForbiddenException(
-        'You are not a participant of this conversation',
-      );
+    this.checkIsParticipant(conversation, establishmentId, establishmentType);
 
     await this.messagesRepository.update(
       {
@@ -182,10 +178,27 @@ export class ConversationsService {
       { isReadByRecipient: true },
     );
 
-    return this.messagesRepository.find({
+    const messages = await this.messagesRepository.find({
       where: { conversationId },
       order: { sentAt: 'ASC' },
+      relations: ['files'],
     });
+
+    return messages.map((message) => ({
+      id: message.id,
+      conversationId: message.conversationId,
+      senderType: message.senderType,
+      content: message.content,
+      sentAt: message.sentAt,
+      isReadByRecipient: message.isReadByRecipient,
+      attachments: message.files.map((file) => ({
+        id: file.id,
+        originalFilename: file.originalFilename,
+        mimeType: file.mimeType,
+        size: file.size,
+        endpoint: this.filesService.getPrivateFileEndpoint(message.id, file.id),
+      })),
+    }));
   }
 
   async getTotalUnreadCount(
@@ -207,5 +220,88 @@ export class ConversationsService {
 
     const count = await queryBuilder.getCount();
     return { count };
+  }
+
+  async sendAttachment(
+    messageId: number,
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+    file: Express.Multer.File,
+  ): Promise<MessageAttachmentResponseDto> {
+    const message = await this.messagesRepository.findOne({
+      where: { id: messageId },
+      relations: ['conversation', 'files'],
+    });
+
+    if (!message) throw new NotFoundException('Message not found');
+
+    this.checkIsParticipant(
+      message.conversation,
+      establishmentId,
+      establishmentType,
+    );
+
+    const storedFile = await this.filesService.create(file);
+
+    message.files.push(storedFile);
+    await this.messagesRepository.save(message);
+
+    return {
+      id: storedFile.id,
+      originalFilename: storedFile.originalFilename,
+      mimeType: storedFile.mimeType,
+      size: storedFile.size,
+      endpoint: this.filesService.getPrivateFileEndpoint(
+        messageId,
+        storedFile.id,
+      ),
+    };
+  }
+
+  async streamAttachment(
+    messageId: number,
+    fileId: number,
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+  ): Promise<StreamableFile> {
+    const message = await this.messagesRepository.findOne({
+      where: { id: messageId },
+      relations: ['conversation', 'files'],
+    });
+
+    if (!message) throw new NotFoundException('Message not found');
+
+    this.checkIsParticipant(
+      message.conversation,
+      establishmentId,
+      establishmentType,
+    );
+
+    const file = message.files.find((f) => f.id === fileId);
+    if (!file) throw new NotFoundException('Attachment not found');
+
+    const fileStream = createReadStream(file.path);
+
+    return new StreamableFile(fileStream, {
+      type: file.mimeType,
+      disposition: `inline; filename="${file.originalFilename}"`,
+    });
+  }
+
+  private checkIsParticipant(
+    conversation: Conversation,
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+  ): void {
+    const isParticipant =
+      (establishmentType === EstablishmentType.RESTAURANT &&
+        conversation.restaurantId === establishmentId) ||
+      (establishmentType === EstablishmentType.SUPPLIER &&
+        conversation.supplierId === establishmentId);
+
+    if (!isParticipant)
+      throw new ForbiddenException(
+        'You are not a participant of this conversation',
+      );
   }
 }

--- a/backend/src/conversations/dto/message-attachments-response.dto.ts
+++ b/backend/src/conversations/dto/message-attachments-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MessageAttachmentResponseDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'document.pdf' })
+  originalFilename: string;
+
+  @ApiProperty({ example: 'application/pdf' })
+  mimeType: string;
+
+  @ApiProperty({ example: 102400 })
+  size: number;
+
+  @ApiProperty({ example: '/messages/1/attachments/2' })
+  endpoint: string;
+}

--- a/backend/src/conversations/dto/message-response.dto.ts
+++ b/backend/src/conversations/dto/message-response.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EstablishmentType } from '../../establishments/enums/establishment-type.enum';
+import { MessageAttachmentResponseDto } from './message-attachments-response.dto';
+
+export class MessageResponseDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 2 })
+  conversationId: number;
+
+  @ApiProperty({ enum: EstablishmentType })
+  senderType: EstablishmentType;
+
+  @ApiProperty({ example: 'Quels sont vos délais de livraison ?' })
+  content: string;
+
+  @ApiProperty({ example: '2026-02-26T20:15:25.000Z' })
+  sentAt: Date;
+
+  @ApiProperty({ example: false })
+  isReadByRecipient: boolean;
+
+  @ApiProperty({ type: [MessageAttachmentResponseDto] })
+  attachments: MessageAttachmentResponseDto[];
+}

--- a/backend/src/conversations/entities/message.entity.ts
+++ b/backend/src/conversations/entities/message.entity.ts
@@ -11,38 +11,28 @@ import {
 } from 'typeorm';
 import { Conversation } from './conversation.entity';
 import { StoredFile } from '../../files/entities/stored-file.entity';
-import { EstablishmentType } from 'src/establishments/enums/establishment-type.enum';
-import { ApiProperty } from '@nestjs/swagger';
+import { EstablishmentType } from '../../establishments/enums/establishment-type.enum';
 
 @Entity('message')
 @Index('idx_message_is_read_by_recipient', ['isReadByRecipient'])
 @Index('idx_message_sent_at', ['sentAt'])
 @Index(['conversationId'])
 export class Message {
-  @ApiProperty({ example: 1 })
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ApiProperty({ example: 2 })
   @Column({ name: 'conversation_id', type: 'int' })
   conversationId: number;
 
-  @ApiProperty({
-    enum: EstablishmentType,
-    example: EstablishmentType.RESTAURANT,
-  })
   @Column({ name: 'sender_type', type: 'enum', enum: EstablishmentType })
   senderType: EstablishmentType;
 
-  @ApiProperty({ example: 'Quels sont vos délais de livraison ?' })
   @Column({ type: 'text' })
   content: string;
 
-  @ApiProperty({ example: '2026-02-26T20:15:25.000Z' })
   @CreateDateColumn({ name: 'sent_at', type: 'datetime' })
   sentAt: Date;
 
-  @ApiProperty({ example: false })
   @Column({ name: 'is_read_by_recipient', type: 'boolean', default: false })
   isReadByRecipient: boolean;
 

--- a/backend/src/conversations/message-attachments.controller.ts
+++ b/backend/src/conversations/message-attachments.controller.ts
@@ -1,0 +1,94 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+  HttpStatus,
+  ParseFilePipeBuilder,
+  StreamableFile,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiConsumes,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiBody,
+} from '@nestjs/swagger';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
+import { EstablishmentGuard } from '../common/guards/establishment.guard';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { multerPrivateOptions } from '../config/multer.config';
+import { MessageAttachmentResponseDto } from './dto/message-attachments-response.dto';
+import { ConversationsService } from './conversations.service';
+
+@ApiTags('messages')
+@ApiBearerAuth()
+@UseGuards(EstablishmentGuard)
+@Controller('messages')
+export class MessageAttachmentsController {
+  constructor(private readonly conversationsService: ConversationsService) {}
+
+  @Post(':messageId/attachments')
+  @ApiOperation({ summary: 'Upload an attachment to a message' })
+  @ApiCreatedResponse({ type: MessageAttachmentResponseDto })
+  @ApiForbiddenResponse({
+    description: 'Not a participant of this conversation',
+  })
+  @ApiNotFoundResponse({ description: 'Message not found' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary' },
+      },
+    },
+  })
+  @UseInterceptors(FileInterceptor('file', multerPrivateOptions))
+  sendAttachment(
+    @Param('messageId', ParseIntPipe) messageId: number,
+    @UploadedFile(
+      new ParseFilePipeBuilder()
+        .addMaxSizeValidator({ maxSize: 10 * 1024 * 1024 })
+        .build({ errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY }),
+    )
+    file: Express.Multer.File,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<MessageAttachmentResponseDto> {
+    return this.conversationsService.sendAttachment(
+      messageId,
+      user.establishmentId!,
+      user.establishmentType!,
+      file,
+    );
+  }
+
+  @Get(':messageId/attachments/:fileId')
+  @ApiOperation({ summary: 'Stream a private attachment' })
+  @ApiOkResponse({ description: 'File stream' })
+  @ApiForbiddenResponse({
+    description: 'Not a participant of this conversation',
+  })
+  @ApiNotFoundResponse({ description: 'Message or file not found' })
+  getAttachment(
+    @Param('messageId', ParseIntPipe) messageId: number,
+    @Param('fileId', ParseIntPipe) fileId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<StreamableFile> {
+    return this.conversationsService.streamAttachment(
+      messageId,
+      fileId,
+      user.establishmentId!,
+      user.establishmentType!,
+    );
+  }
+}

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -21,10 +21,12 @@ import {
   ApiBearerAuth,
   ApiBody,
   ApiConsumes,
+  ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
+  ApiOperation,
   ApiTags,
   ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
@@ -44,7 +46,8 @@ export class DocumentsController {
   constructor(private readonly documentsService: DocumentsService) {}
 
   @Post()
-  @ApiOkResponse({ type: DocumentResponseDto })
+  @ApiOperation({ summary: 'Upload a document' })
+  @ApiCreatedResponse({ type: DocumentResponseDto })
   @ApiBadRequestResponse({
     description: 'Invalid file type or category limit reached',
   })
@@ -95,6 +98,7 @@ export class DocumentsController {
   }
 
   @Get()
+  @ApiOperation({ summary: 'Get all documents grouped by category' })
   @ApiOkResponse({
     description: 'Documents grouped by category',
     type: GroupedDocumentsResponseDto,
@@ -109,6 +113,7 @@ export class DocumentsController {
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Delete a document' })
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiNoContentResponse({ description: 'Document deleted successfully' })
   @ApiNotFoundResponse({ description: 'Document not found' })

--- a/backend/src/documents/documents.service.ts
+++ b/backend/src/documents/documents.service.ts
@@ -43,7 +43,7 @@ export class DocumentsService {
     DocumentCategory.GALLERY_PHOTO,
   ];
 
-  // Upload a document(with category-specific rules)
+  // Upload a document after validating category-specific rules
   async upload(
     establishmentId: number,
     establishmentType: EstablishmentType | null,

--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -60,4 +60,8 @@ export class FilesService {
 
     return `${baseUrl}${PUBLIC_STATIC_URL_PREFIX}/${storedFilename}`;
   }
+
+  getPrivateFileEndpoint(messageId: number, fileId: number): string {
+    return `/messages/${messageId}/attachments/${fileId}`;
+  }
 }

--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -15,6 +15,7 @@ export class FilesService {
     private readonly filesRepository: Repository<StoredFile>,
   ) {}
 
+  // Saves file metadata to DB using the path already written to disk by Multer
   async create(file: Express.Multer.File): Promise<StoredFile> {
     const relativePath = path.relative(process.cwd(), file.path);
 
@@ -39,17 +40,17 @@ export class FilesService {
     return file;
   }
 
+  // Deletes physical file from disk first, then removes DB record
+  // If disk deletion fails, logs error but still removes DB record
   async delete(id: number): Promise<void> {
     const file = await this.findOne(id);
 
-    // Delete physical file
     try {
       await fs.unlink(file.path);
     } catch (error) {
       console.error(`Error deleting file ${file.path}:`, error);
     }
 
-    // Remove from database
     await this.filesRepository.remove(file);
   }
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -4,7 +4,6 @@ import {
   Body,
   Patch,
   Delete,
-  Request,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -15,9 +14,9 @@ import {
   ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
+  ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { ApiOperation } from '@nestjs/swagger';
 import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
 import { User } from './entities/user.entity';
 import { CurrentUser } from '../common/decorators/current-user.decorator';

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -19,6 +19,7 @@ export class UsersService {
     private readonly configService: ConfigService,
   ) {}
 
+  // Hashes the password before saving the user, throws if email already exists
   async create(createUserDto: CreateUserDto): Promise<User> {
     const existingUser = await this.findByEmail(createUserDto.email);
     if (existingUser) {
@@ -49,6 +50,7 @@ export class UsersService {
     return this.usersRepository.findOne({ where: { email } });
   }
 
+  // Used during JWT validation to load the user with their establishment
   async findByEmailWithEstablishment(email: string): Promise<User | null> {
     return this.usersRepository.findOne({
       where: { email },


### PR DESCRIPTION
This PR adds private file attachment support to the messaging system.

### Features
- `POST /messages/:messageId/attachments` — upload a private attachment
- `GET /messages/:messageId/attachments/:fileId` — stream a private attachment

### Architecture
- New `MessageAttachmentsController` dedicated to attachment routes
- Attachments stored in `uploads/private/attachments` (not publicly accessible)
- Files served via authenticated streaming using NestJS `StreamableFile`
- Mime type validation at Multer level (images and PDF only)

### Changes
- `getConversationMessages` now returns `MessageResponseDto[]` including attachments
- `sendMessage` now returns `MessageResponseDto` for consistency
- `DocumentsController` — added missing `@ApiOperation` decorators

### Documentation
- Swagger documentation for new endpoints
- Inline comments added to services