### PR TITLE
Implement Reviews module with role-based access, single-review constraint and supplier reply support – Issue #30

### DIFF
--- a/backend/src/establishments/entities/establishment.entity.ts
+++ b/backend/src/establishments/entities/establishment.entity.ts
@@ -97,7 +97,7 @@ export class Establishment {
   favoritesReceived: Favorite[];
 
   // Un établissement (type: 'RESTAURANT') peut laisser des avis sur plusieurs fournisseurs
-  @OneToMany(() => Review, (review) => review.owner)
+  @OneToMany(() => Review, (review) => review.reviewer)
   reviewsGiven: Review[];
 
   // Un établissement (type: 'SUPPLIER') peut recevoir des avis de plusieurs restaurants

--- a/backend/src/reviews/dto/create-review.dto.ts
+++ b/backend/src/reviews/dto/create-review.dto.ts
@@ -1,1 +1,29 @@
-export class CreateReviewDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsPositive,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+export class CreateReviewDto {
+  @ApiProperty({ example: 3 })
+  @IsInt()
+  @IsPositive()
+  supplierId: number;
+
+  @ApiProperty({ example: 4, minimum: 1, maximum: 5 })
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating: number;
+
+  @ApiProperty({ example: 'Great supplier, deliveries always on time.' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  comment: string;
+}

--- a/backend/src/reviews/dto/reply-review.dto.ts
+++ b/backend/src/reviews/dto/reply-review.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class ReplyReviewDto {
+  @ApiProperty({
+    example: 'Thank you for your feedback!',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  reply: string;
+}

--- a/backend/src/reviews/dto/review-response.dto.ts
+++ b/backend/src/reviews/dto/review-response.dto.ts
@@ -1,0 +1,28 @@
+// review-response.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReviewResponseDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 4 })
+  rating: number;
+
+  @ApiProperty({ example: 'Great supplier, deliveries always on time.' })
+  comment: string;
+
+  @ApiProperty({ example: 'Thank you for your feedback!', nullable: true })
+  reply: string | null;
+
+  @ApiProperty({ example: '2026-02-26T20:15:25.000Z', nullable: true })
+  repliedAt: Date | null;
+
+  @ApiProperty({ example: '2026-02-22T13:49:30.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: { id: 3, name: 'Le Petit Bistrot' } })
+  reviewer: {
+    id: number;
+    name: string;
+  };
+}

--- a/backend/src/reviews/dto/supplier-reviews-response.dto.ts
+++ b/backend/src/reviews/dto/supplier-reviews-response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ReviewResponseDto } from './review-response.dto';
+
+export class SupplierReviewsResponseDto {
+  @ApiProperty({ example: 4.2 })
+  average: number;
+
+  @ApiProperty({ example: 15 })
+  count: number;
+
+  @ApiProperty({ type: [ReviewResponseDto] })
+  reviews: ReviewResponseDto[];
+}

--- a/backend/src/reviews/dto/update-review.dto.ts
+++ b/backend/src/reviews/dto/update-review.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateReviewDto } from './create-review.dto';
-
-export class UpdateReviewDto extends PartialType(CreateReviewDto) {}

--- a/backend/src/reviews/entities/review.entity.ts
+++ b/backend/src/reviews/entities/review.entity.ts
@@ -34,6 +34,12 @@ export class Review {
   @Column({ type: 'text' })
   comment: string;
 
+  @Column({ type: 'text', nullable: true })
+  reply: string | null;
+
+  @Column({ name: 'replied_at', type: 'datetime', nullable: true })
+  repliedAt: Date | null;
+
   @Column({ type: 'enum', enum: ReviewStatus, default: ReviewStatus.PUBLISHED })
   status: ReviewStatus;
 
@@ -51,7 +57,7 @@ export class Review {
     },
   )
   @JoinColumn({ name: 'reviewer_restaurant_id' })
-  owner: Establishment;
+  reviewer: Establishment;
 
   // Chaque avis est lié à un fournisseur (target)
   @ManyToOne(

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -31,6 +31,7 @@ import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
 import { ReviewResponseDto } from './dto/review-response.dto';
 import { ReplyReviewDto } from './dto/reply-review.dto';
+import { SupplierReviewsResponseDto } from './dto/supplier-reviews-response.dto';
 
 @ApiTags('reviews')
 @ApiBearerAuth()
@@ -60,11 +61,11 @@ export class ReviewsController {
 
   @Get()
   @ApiOperation({ summary: 'Get all reviews for a supplier' })
-  @ApiOkResponse({ type: [ReviewResponseDto] })
+  @ApiOkResponse({ type: SupplierReviewsResponseDto })
   @ApiQuery({ name: 'supplierId', type: Number, required: true })
   getSupplierReviews(
     @Query('supplierId', ParseIntPipe) supplierId: number,
-  ): Promise<ReviewResponseDto[]> {
+  ): Promise<SupplierReviewsResponseDto> {
     return this.reviewsService.getSupplierReviews(supplierId);
   }
 

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -6,39 +6,103 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
+  Query,
+  ParseIntPipe,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
-import { UpdateReviewDto } from './dto/update-review.dto';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { EstablishmentGuard } from '../common/guards/establishment.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
+import { ReviewResponseDto } from './dto/review-response.dto';
+import { ReplyReviewDto } from './dto/reply-review.dto';
 
 @ApiTags('reviews')
+@ApiBearerAuth()
+@UseGuards(EstablishmentGuard)
 @Controller('reviews')
 export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) {}
 
   @Post()
-  create(@Body() createReviewDto: CreateReviewDto) {
-    return this.reviewsService.create(createReviewDto);
+  @ApiOperation({ summary: 'Create a review for a supplier' })
+  @ApiCreatedResponse({ type: ReviewResponseDto })
+  @ApiForbiddenResponse({ description: 'Only restaurants can create reviews' })
+  @ApiNotFoundResponse({ description: 'Supplier not found' })
+  @ApiConflictResponse({
+    description: 'You have already reviewed this supplier',
+  })
+  createReview(
+    @Body() createReviewDto: CreateReviewDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<ReviewResponseDto> {
+    return this.reviewsService.createReview(
+      user.establishmentId!,
+      user.establishmentType!,
+      createReviewDto,
+    );
   }
 
   @Get()
-  findAll() {
-    return this.reviewsService.findAll();
+  @ApiOperation({ summary: 'Get all reviews for a supplier' })
+  @ApiOkResponse({ type: [ReviewResponseDto] })
+  @ApiQuery({ name: 'supplierId', type: Number, required: true })
+  getSupplierReviews(
+    @Query('supplierId', ParseIntPipe) supplierId: number,
+  ): Promise<ReviewResponseDto[]> {
+    return this.reviewsService.getSupplierReviews(supplierId);
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.reviewsService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateReviewDto: UpdateReviewDto) {
-    return this.reviewsService.update(+id, updateReviewDto);
+  @Patch(':id/reply')
+  @ApiOperation({ summary: 'Reply to a review' })
+  @ApiOkResponse({ type: ReviewResponseDto })
+  @ApiForbiddenResponse({ description: 'Only suppliers can reply to reviews' })
+  @ApiNotFoundResponse({ description: 'Review not found' })
+  @ApiConflictResponse({
+    description: 'You have already replied to this review',
+  })
+  replyToReview(
+    @Param('id', ParseIntPipe) reviewId: number,
+    @Body() replyReviewDto: ReplyReviewDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<ReviewResponseDto> {
+    return this.reviewsService.replyToReview(
+      reviewId,
+      user.establishmentId!,
+      user.establishmentType!,
+      replyReviewDto,
+    );
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.reviewsService.remove(+id);
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a review' })
+  @ApiNoContentResponse({ description: 'Review deleted successfully' })
+  @ApiForbiddenResponse({ description: 'Only restaurants can delete reviews' })
+  @ApiNotFoundResponse({ description: 'Review not found' })
+  deleteReview(
+    @Param('id', ParseIntPipe) reviewId: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<void> {
+    return this.reviewsService.deleteReview(
+      reviewId,
+      user.establishmentId!,
+      user.establishmentType!,
+    );
   }
 }

--- a/backend/src/reviews/reviews.module.ts
+++ b/backend/src/reviews/reviews.module.ts
@@ -3,9 +3,10 @@ import { ReviewsService } from './reviews.service';
 import { ReviewsController } from './reviews.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Review } from './entities/review.entity';
+import { Establishment } from '../establishments/entities/establishment.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Review])],
+  imports: [TypeOrmModule.forFeature([Review, Establishment])],
   controllers: [ReviewsController],
   providers: [ReviewsService],
 })

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -1,26 +1,149 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateReviewDto } from './dto/create-review.dto';
-import { UpdateReviewDto } from './dto/update-review.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Review } from './entities/review.entity';
+import { Repository } from 'typeorm';
+import { Establishment } from '../establishments/entities/establishment.entity';
+import { EstablishmentType } from '../establishments/enums/establishment-type.enum';
+import { ReviewResponseDto } from './dto/review-response.dto';
+import { ReplyReviewDto } from './dto/reply-review.dto';
 
 @Injectable()
 export class ReviewsService {
-  create(createReviewDto: CreateReviewDto) {
-    return `This action adds a new review ${JSON.stringify(createReviewDto)}`;
+  constructor(
+    @InjectRepository(Review) private reviewsRepository: Repository<Review>,
+    @InjectRepository(Establishment)
+    private establishmentsRepository: Repository<Establishment>,
+  ) {}
+
+  // Only restaurants can create a review, one review per supplier
+  async createReview(
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+    dto: CreateReviewDto,
+  ): Promise<ReviewResponseDto> {
+    if (establishmentType !== EstablishmentType.RESTAURANT) {
+      throw new ForbiddenException('Only restaurants can create reviews');
+    }
+
+    const supplier = await this.establishmentsRepository.findOne({
+      where: {
+        id: dto.supplierId,
+        type: EstablishmentType.SUPPLIER,
+      },
+    });
+
+    if (!supplier) throw new NotFoundException('Supplier not found');
+
+    const existingReview = await this.reviewsRepository.findOne({
+      where: {
+        reviewerRestaurantId: establishmentId,
+        reviewedSupplierId: dto.supplierId,
+      },
+    });
+
+    if (existingReview) {
+      throw new ConflictException('You have already reviewed this supplier');
+    }
+
+    const review = this.reviewsRepository.create({
+      reviewerRestaurantId: establishmentId,
+      reviewedSupplierId: dto.supplierId,
+      rating: dto.rating,
+      comment: dto.comment,
+    });
+    const saved = await this.reviewsRepository.save(review);
+
+    const restaurant = await this.establishmentsRepository.findOne({
+      where: { id: establishmentId },
+    });
+
+    return this.toResponseDto(saved, restaurant!);
   }
 
-  findAll() {
-    return `This action returns all reviews`;
+  async getSupplierReviews(supplierId: number): Promise<ReviewResponseDto[]> {
+    const reviews = await this.reviewsRepository.find({
+      where: { reviewedSupplierId: supplierId },
+      relations: ['reviewer'],
+      order: { createdAt: 'DESC' },
+    });
+
+    return reviews.map((review) => this.toResponseDto(review, review.reviewer));
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} review`;
+  // Only the reviewed supplier can reply, one reply per review
+  async replyToReview(
+    reviewId: number,
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+    dto: ReplyReviewDto,
+  ): Promise<ReviewResponseDto> {
+    if (establishmentType !== EstablishmentType.SUPPLIER) {
+      throw new ForbiddenException('Only suppliers can reply to reviews');
+    }
+
+    const review = await this.reviewsRepository.findOne({
+      where: { id: reviewId },
+      relations: ['reviewer'],
+    });
+
+    if (!review) throw new NotFoundException('Review not found');
+
+    if (review.reviewedSupplierId !== establishmentId) {
+      throw new ForbiddenException(
+        'This review is not about your establishment',
+      );
+    }
+    if (review.reply) {
+      throw new ConflictException('You have already replied to this review');
+    }
+
+    review.reply = dto.reply;
+    review.repliedAt = new Date();
+    const saved = await this.reviewsRepository.save(review);
+
+    return this.toResponseDto(saved, review.reviewer);
   }
 
-  update(id: number, updateReviewDto: UpdateReviewDto) {
-    return `This action updates a #${id} review ${JSON.stringify(updateReviewDto)}`;
+  // Only the restaurant author can delete his own review
+  async deleteReview(
+    reviewId: number,
+    establishmentId: number,
+    establishmentType: EstablishmentType,
+  ): Promise<void> {
+    if (establishmentType !== EstablishmentType.RESTAURANT) {
+      throw new ForbiddenException('Only restaurants can delete reviews');
+    }
+    const review = await this.reviewsRepository.findOneBy({ id: reviewId });
+    if (!review) throw new NotFoundException('Review not found');
+    if (review.reviewerRestaurantId !== establishmentId) {
+      throw new ForbiddenException('You are not the author of this review');
+    }
+
+    await this.reviewsRepository.remove(review);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} review`;
+  // Maps a Review entity to ReviewResponseDto
+  private toResponseDto(
+    review: Review,
+    reviewer: Establishment,
+  ): ReviewResponseDto {
+    return {
+      id: review.id,
+      rating: review.rating,
+      comment: review.comment,
+      reply: review.reply,
+      repliedAt: review.repliedAt,
+      createdAt: review.createdAt,
+      reviewer: {
+        id: reviewer.id,
+        name: reviewer.tradeName ?? reviewer.legalName,
+      },
+    };
   }
 }

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -12,6 +12,7 @@ import { Establishment } from '../establishments/entities/establishment.entity';
 import { EstablishmentType } from '../establishments/enums/establishment-type.enum';
 import { ReviewResponseDto } from './dto/review-response.dto';
 import { ReplyReviewDto } from './dto/reply-review.dto';
+import { SupplierReviewsResponseDto } from './dto/supplier-reviews-response.dto';
 
 @Injectable()
 export class ReviewsService {
@@ -66,14 +67,30 @@ export class ReviewsService {
     return this.toResponseDto(saved, restaurant!);
   }
 
-  async getSupplierReviews(supplierId: number): Promise<ReviewResponseDto[]> {
+  async getSupplierReviews(
+    supplierId: number,
+  ): Promise<SupplierReviewsResponseDto> {
     const reviews = await this.reviewsRepository.find({
       where: { reviewedSupplierId: supplierId },
       relations: ['reviewer'],
       order: { createdAt: 'DESC' },
     });
 
-    return reviews.map((review) => this.toResponseDto(review, review.reviewer));
+    const count = reviews.length;
+    const average =
+      count > 0
+        ? Math.round(
+            (reviews.reduce((sum, r) => sum + r.rating, 0) / count) * 10,
+          ) / 10
+        : 0;
+
+    return {
+      average,
+      count,
+      reviews: reviews.map((review) =>
+        this.toResponseDto(review, review.reviewer),
+      ),
+    };
   }
 
   // Only the reviewed supplier can reply, one reply per review


### PR DESCRIPTION
This PR introduces a Reviews module allowing restaurants to review suppliers and suppliers to reply.

## Features

- POST /reviews - Restaurant creates a review for a supplier  
- GET /reviews?supplierId=XX - Retrieve all reviews for a supplier with average rating  
- PATCH /reviews/:id/reply - Supplier replies to a review  
- DELETE /reviews/:id - Restaurant deletes its own review  

## Business Rules

- Only restaurants can create or delete reviews  
- Only suppliers can reply to reviews  
- One review per restaurant per supplier  
- One reply per review  

## Architecture

- Dedicated ReviewsService and ReviewsController  
- DTO mapping (ReviewResponseDto, SupplierReviewsResponseDto)  
- Role validation handled at service level  
- Average rating calculated and rounded to 1 decimal  

## Documentation

- Swagger documentation added for all endpoints  