### PR TITLE
Add public document management UI (upload, view, delete) – Issue #37

### DIFF
--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -1,0 +1,35 @@
+import type {
+  DocumentCategory,
+  DocumentResponse,
+  GroupedDocuments,
+} from "../types/documents.types";
+import api from "./axiosConfig";
+
+// Upload a public document (logo, cover photo, catalog, gallery photo) for the establishment
+export const uploadDocument = async (
+  file: File,
+  category: DocumentCategory,
+): Promise<DocumentResponse> => {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("category", category);
+
+  const response = await api.post("/documents", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  return response.data;
+};
+
+// Fetch all documents for the establishment, grouped by category
+export const getDocuments = async (): Promise<GroupedDocuments> => {
+  const response = await api.get("/documents");
+  return response.data;
+};
+
+// Delete a document by its ID
+export const deleteDocument = async (documentId: number): Promise<void> => {
+  await api.delete(`/documents/${documentId}`);
+};

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -18,6 +18,7 @@ export const uploadDocument = async (
     headers: {
       "Content-Type": "multipart/form-data",
     },
+    timeout: 30000, // 30 seconds timeout for uploads
   });
 
   return response.data;

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -54,9 +54,9 @@ function LoginForm() {
 
     // Email validation
     if (!isNotEmptyString(email)) {
-      newErrors.email = "L'email est requis";
+      newErrors.email = "L'email est requis.";
     } else if (!isEmailValid(email)) {
-      newErrors.email = "Email invalide";
+      newErrors.email = "Email invalide.";
     }
 
     // Password validation
@@ -90,7 +90,7 @@ function LoginForm() {
       }
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 401) {
-        setErrors({ general: "Email ou mot de passe incorrect" });
+        setErrors({ general: "Email ou mot de passe incorrect." });
       } else {
         toast.error("Une erreur est survenue lors de la connexion.");
       }

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -64,17 +64,17 @@ function RegisterForm() {
 
     // First name and last name validation
     if (!isNotEmptyString(firstName)) {
-      newErrors.firstName = "Le prénom est requis";
+      newErrors.firstName = "Le prénom est requis.";
     }
     if (!isNotEmptyString(lastName)) {
-      newErrors.lastName = "Le nom est requis";
+      newErrors.lastName = "Le nom est requis.";
     }
 
     // Email validation
     if (!isNotEmptyString(email)) {
-      newErrors.email = "L'email est requis";
+      newErrors.email = "L'email est requis.";
     } else if (!isEmailValid(email)) {
-      newErrors.email = "Email invalide";
+      newErrors.email = "Email invalide.";
     }
 
     // Password validation
@@ -94,9 +94,10 @@ function RegisterForm() {
 
     // Confirm password validation
     if (!isNotEmptyString(confirmPassword)) {
-      newErrors.confirmPassword = "La confirmation du mot de passe est requise";
+      newErrors.confirmPassword =
+        "La confirmation du mot de passe est requise.";
     } else if (formData.password !== confirmPassword) {
-      newErrors.confirmPassword = "Les mots de passe ne correspondent pas";
+      newErrors.confirmPassword = "Les mots de passe ne correspondent pas.";
     }
 
     // If errors, stop here
@@ -121,9 +122,9 @@ function RegisterForm() {
       navigate("/onboarding/create-establishment");
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 409) {
-        setErrors({ email: "Cet email est déjà utilisé" });
+        setErrors({ email: "Cet email est déjà utilisé." });
       } else {
-        toast.error("Une erreur est survenue lors de l'inscription");
+        toast.error("Une erreur est survenue lors de l'inscription.");
       }
     } finally {
       setIsLoading(false);

--- a/frontend/src/components/documents/DocumentCard.tsx
+++ b/frontend/src/components/documents/DocumentCard.tsx
@@ -5,15 +5,12 @@ import type { DocumentItem } from "../../types/documents.types";
 import toast from "react-hot-toast";
 import { useState } from "react";
 
-type DocumentPreviewAndDeleteProps = {
+type DocumentCardProps = {
   document: DocumentItem;
   onDeleteSuccess: () => void;
 };
 
-function DocumentPreviewAndDelete({
-  document,
-  onDeleteSuccess,
-}: DocumentPreviewAndDeleteProps) {
+function DocumentCard({ document, onDeleteSuccess }: DocumentCardProps) {
   const [showConfirm, setShowConfirm] = useState(false);
 
   const handleTrashClick = () => {
@@ -39,11 +36,11 @@ function DocumentPreviewAndDelete({
   // Image
   if (document.file.mimeType.startsWith("image/")) {
     return (
-      <div className="relative rounded-lg shadow-md shadow-brand-dark/60 overflow-hidden">
+      <div className="relative shadow-md shadow-brand-dark/60 rounded-lg">
         <img
           src={document.file.url}
           alt={document.file.originalFilename}
-          className="w-full h-auto sm:h-40 sm:w-auto object-cover"
+          className="w-full h-auto sm:h-40 sm:w-auto object-cover rounded-lg"
         />
         <div className="absolute top-2 right-2">
           {!showConfirm ? (
@@ -122,4 +119,4 @@ function DocumentPreviewAndDelete({
   );
 }
 
-export default DocumentPreviewAndDelete;
+export default DocumentCard;

--- a/frontend/src/components/documents/DocumentPreviewAndDelete.tsx
+++ b/frontend/src/components/documents/DocumentPreviewAndDelete.tsx
@@ -1,0 +1,125 @@
+//
+import { ExternalLink, Trash2 } from "lucide-react";
+import { deleteDocument } from "../../api/documents";
+import type { DocumentItem } from "../../types/documents.types";
+import toast from "react-hot-toast";
+import { useState } from "react";
+
+type DocumentPreviewAndDeleteProps = {
+  document: DocumentItem;
+  onDeleteSuccess: () => void;
+};
+
+function DocumentPreviewAndDelete({
+  document,
+  onDeleteSuccess,
+}: DocumentPreviewAndDeleteProps) {
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const handleTrashClick = () => {
+    setShowConfirm(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    setShowConfirm(false);
+    try {
+      await deleteDocument(document.id);
+      toast.success("Document supprimé");
+      onDeleteSuccess();
+    } catch (error) {
+      console.error("Error deleting document:", error);
+      toast.error("Erreur lors de la suppression du document");
+    }
+  };
+
+  const handleCancel = () => {
+    setShowConfirm(false);
+  };
+
+  // Image
+  if (document.file.mimeType.startsWith("image/")) {
+    return (
+      <div className="relative rounded-lg shadow-md shadow-brand-dark/60 overflow-hidden">
+        <img
+          src={document.file.url}
+          alt={document.file.originalFilename}
+          className="w-full h-auto sm:h-40 sm:w-auto object-cover"
+        />
+        <div className="absolute top-2 right-2">
+          {!showConfirm ? (
+            <button
+              onClick={handleTrashClick}
+              className="btn rounded-full p-1.5 border-2 border-cream"
+              aria-label="Supprimer le document"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          ) : (
+            <div className="flex flex-col gap-2 bg-white p-3 rounded-lg shadow-lg border border-gray-200">
+              <p className="text-sm font-medium text-brand-light whitespace-nowrap">
+                Supprimer ?
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleConfirmDelete}
+                  className="btn text-sm px-3 py-1.5"
+                >
+                  Oui
+                </button>
+                <button
+                  onClick={handleCancel}
+                  className="btn btn-ghost text-brand-light text-sm px-3 py-1.5"
+                >
+                  Non
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // PDF
+  return (
+    <div className="relative">
+      <div className="bg-white flex items-center gap-3 p-3 shadow-md shadow-brand-dark/60 rounded-lg">
+        <a
+          href={document.file.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-1  text-brand-light font-medium truncate hover:underline"
+        >
+          {document.file.originalFilename}
+          <ExternalLink className="inline ml-2 w-7 h-7 p-1 transition hover:-translate-y-0.5" />
+        </a>
+
+        <button
+          onClick={handleTrashClick}
+          className="btn rounded-full p-1.5"
+          aria-label="Supprimer le document"
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
+      </div>
+      {showConfirm && (
+        <div className="absolute top-full w-full left-0 mt-2 z-10 flex items-center gap-2 bg-white px-4 py-2 rounded-lg shadow-md shadow-brand-dark/60 whitespace-nowrap">
+          <span className="text-sm font-medium text-brand-light mr-4">
+            Supprimer ?
+          </span>
+          <button onClick={handleConfirmDelete} className="btn text-sm py-1.5">
+            Oui
+          </button>
+          <button
+            onClick={handleCancel}
+            className="btn btn-ghost text-brand-light text-sm"
+          >
+            Non
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DocumentPreviewAndDelete;

--- a/frontend/src/components/documents/DocumentUploadButton.tsx
+++ b/frontend/src/components/documents/DocumentUploadButton.tsx
@@ -6,27 +6,45 @@ import { DocumentCategory } from "../../types/documents.types";
 
 type DocumentUploadButtonProps = {
   category: DocumentCategory;
-  accept: string; // "image/png, image/jpeg, image/webp" ou "application/pdf"
+  allowedMimeTypes: string[]; // ["image/png", "image/jpeg", "image/webp"] ou ["application/pdf"]
   label: string;
   onUploadSuccess: () => void;
 };
 
 function DocumentUploadButton({
   category,
-  accept,
+  allowedMimeTypes,
   label,
   onUploadSuccess,
 }: DocumentUploadButtonProps) {
   const [isUploading, setIsUploading] = useState(false);
+  const [helperText, setHelperText] = useState<string | null>(null);
 
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    setHelperText(null); // Reset helper text
 
-    // Validate file size (10MB max)
-    const maxSize = 10 * 1024 * 1024;
+    // Validate file size (20MB max)
+    const maxSize = 20 * 1024 * 1024;
     if (file.size > maxSize) {
-      toast.error("Fichier trop volumineux. Taille maximale : 10 Mo");
+      toast.error("Le fichier est trop volumineux.");
+      setHelperText("Taille maximale : 20 Mo");
+      e.target.value = ""; // Reset input
+      return;
+    }
+
+    // Validate file type
+    if (!allowedMimeTypes.includes(file.type)) {
+      toast.error("Type de fichier non autorisé.");
+      const formats = allowedMimeTypes.map((type) =>
+        type.split("/")[1].toUpperCase(),
+      );
+      const formatsText =
+        formats.length > 1
+          ? `${formats.slice(0, -1).join(", ")} et ${formats.slice(-1)}`
+          : formats[0];
+      setHelperText(`Seuls les fichiers ${formatsText} sont acceptés.`);
       e.target.value = ""; // Reset input
       return;
     }
@@ -47,17 +65,19 @@ function DocumentUploadButton({
   };
 
   return (
-    <label className="btn inline-flex items-center gap-2 cursor-pointer">
-      <Upload className="w-4 h-4" />
-      <span>{isUploading ? "Téléchargement en cours..." : label}</span>
-      <input
-        type="file"
-        accept={accept}
-        onChange={handleFileChange}
-        disabled={isUploading}
-        className="sr-only"
-      />
-    </label>
+    <div>
+      <label className="btn">
+        <Upload className="w-4 h-4" />
+        <span>{isUploading ? "Téléchargement en cours..." : label}</span>
+        <input
+          type="file"
+          onChange={handleFileChange}
+          disabled={isUploading}
+          className="sr-only"
+        />
+      </label>
+      {helperText && <p className="mt-2 text-sm text-accent">{helperText}</p>}
+    </div>
   );
 }
 

--- a/frontend/src/components/documents/DocumentUploadButton.tsx
+++ b/frontend/src/components/documents/DocumentUploadButton.tsx
@@ -1,0 +1,64 @@
+import { useState, type ChangeEvent } from "react";
+import { Upload } from "lucide-react";
+import toast from "react-hot-toast";
+import { uploadDocument } from "../../api/documents";
+import { DocumentCategory } from "../../types/documents.types";
+
+type DocumentUploadButtonProps = {
+  category: DocumentCategory;
+  accept: string; // "image/png, image/jpeg, image/webp" ou "application/pdf"
+  label: string;
+  onUploadSuccess: () => void;
+};
+
+function DocumentUploadButton({
+  category,
+  accept,
+  label,
+  onUploadSuccess,
+}: DocumentUploadButtonProps) {
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Validate file size (10MB max)
+    const maxSize = 10 * 1024 * 1024;
+    if (file.size > maxSize) {
+      toast.error("Fichier trop volumineux. Taille maximale : 10 Mo");
+      e.target.value = ""; // Reset input
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      await uploadDocument(file, category);
+      toast.success("Document téléchargé avec succès !");
+      onUploadSuccess();
+      e.target.value = ""; // Reset input
+    } catch (error) {
+      console.error("Upload error:", error);
+      toast.error("Erreur lors du téléchargement");
+      e.target.value = ""; // Reset input
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <label className="btn inline-flex items-center gap-2 cursor-pointer">
+      <Upload className="w-4 h-4" />
+      <span>{isUploading ? "Téléchargement en cours..." : label}</span>
+      <input
+        type="file"
+        accept={accept}
+        onChange={handleFileChange}
+        disabled={isUploading}
+        className="sr-only"
+      />
+    </label>
+  );
+}
+
+export default DocumentUploadButton;

--- a/frontend/src/components/documents/DocumentsList.tsx
+++ b/frontend/src/components/documents/DocumentsList.tsx
@@ -4,7 +4,7 @@ import { type GroupedDocuments } from "../../types/documents.types";
 import { getDocuments } from "../../api/documents";
 import { useAuth } from "../../hooks/useAuth";
 import { EstablishmentType } from "../../types/establishments.types";
-import DocumentPreviewAndDelete from "./DocumentPreviewAndDelete";
+import DocumentCard from "./DocumentCard";
 import DocumentUploadButton from "./DocumentUploadButton";
 
 function DocumentsList() {
@@ -50,18 +50,18 @@ function DocumentsList() {
             <h3 className="text-2xl font-semibold mb-4">Logo</h3>
             {documents.LOGO[0] ? (
               <div className="space-y-3 flex flex-col items-center">
-                <DocumentPreviewAndDelete
+                <DocumentCard
                   document={documents.LOGO[0]}
                   onDeleteSuccess={fetchDocuments}
                 />
-                <p className="text-sm italic text-center max-w-xs">
+                <p className="text-sm italic text-center">
                   Supprimez le logo pour en télécharger un nouveau.
                 </p>
               </div>
             ) : (
               <DocumentUploadButton
                 category="LOGO"
-                accept="image/png, image/jpeg, image/webp"
+                allowedMimeTypes={["image/png", "image/jpeg", "image/webp"]}
                 label="Ajouter votre logo"
                 onUploadSuccess={fetchDocuments}
               />
@@ -73,18 +73,18 @@ function DocumentsList() {
             <h3 className="text-2xl font-semibold mb-4">Photo de couverture</h3>
             {documents.COVER_PHOTO[0] ? (
               <div className="space-y-3 flex flex-col items-center">
-                <DocumentPreviewAndDelete
+                <DocumentCard
                   document={documents.COVER_PHOTO[0]}
                   onDeleteSuccess={fetchDocuments}
                 />
-                <p className="text-sm italic text-center max-w-xs">
+                <p className="text-sm italic text-center">
                   Supprimez la photo pour en télécharger une nouvelle.
                 </p>
               </div>
             ) : (
               <DocumentUploadButton
                 category="COVER_PHOTO"
-                accept="image/*"
+                allowedMimeTypes={["image/png", "image/jpeg", "image/webp"]}
                 label="Ajouter votre photo de couverture"
                 onUploadSuccess={fetchDocuments}
               />
@@ -97,18 +97,18 @@ function DocumentsList() {
               <h3 className="text-2xl font-semibold mb-4">Catalogue</h3>
               {documents.CATALOG[0] ? (
                 <div className="space-y-3 flex flex-col items-center">
-                  <DocumentPreviewAndDelete
+                  <DocumentCard
                     document={documents.CATALOG[0]}
                     onDeleteSuccess={fetchDocuments}
                   />
-                  <p className="text-sm italic text-center max-w-xs">
+                  <p className="text-sm italic text-center">
                     Supprimez le catalogue pour en télécharger un nouveau.
                   </p>
                 </div>
               ) : (
                 <DocumentUploadButton
                   category="CATALOG"
-                  accept="application/pdf"
+                  allowedMimeTypes={["application/pdf"]}
                   label="Ajouter votre catalogue (PDF)"
                   onUploadSuccess={fetchDocuments}
                 />
@@ -127,7 +127,7 @@ function DocumentsList() {
             {documents.GALLERY_PHOTO.length > 0 && (
               <div className="flex flex-wrap gap-6 flex-col sm:flex-row mb-4 max-w-4xl">
                 {documents.GALLERY_PHOTO.map((doc) => (
-                  <DocumentPreviewAndDelete
+                  <DocumentCard
                     key={doc.id}
                     document={doc}
                     onDeleteSuccess={fetchDocuments}
@@ -139,7 +139,7 @@ function DocumentsList() {
             {documents.GALLERY_PHOTO.length < 6 ? (
               <DocumentUploadButton
                 category="GALLERY_PHOTO"
-                accept="image/*"
+                allowedMimeTypes={["image/png", "image/jpeg", "image/webp"]}
                 label="Ajouter une photo"
                 onUploadSuccess={fetchDocuments}
               />

--- a/frontend/src/components/documents/DocumentsList.tsx
+++ b/frontend/src/components/documents/DocumentsList.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import { type GroupedDocuments } from "../../types/documents.types";
+import { getDocuments } from "../../api/documents";
+import { useAuth } from "../../hooks/useAuth";
+import { EstablishmentType } from "../../types/establishments.types";
+import DocumentPreviewAndDelete from "./DocumentPreviewAndDelete";
+import DocumentUploadButton from "./DocumentUploadButton";
+
+function DocumentsList() {
+  const { user } = useAuth();
+  const [documents, setDocuments] = useState<GroupedDocuments>({
+    LOGO: [],
+    COVER_PHOTO: [],
+    CATALOG: [],
+    GALLERY_PHOTO: [],
+  });
+  const [loading, setLoading] = useState(true);
+
+  const fetchDocuments = async () => {
+    try {
+      const data = await getDocuments();
+      setDocuments(data);
+    } catch (error) {
+      console.error("Error fetching documents:", error);
+      toast.error("Erreur lors du chargement des documents");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDocuments();
+  }, []);
+
+  if (loading) {
+    return <div className="text-center py-12">Chargement...</div>;
+  }
+
+  return (
+    <section className="bg-[#fdf4ef] border-2 border-brand-dark max-w-6xl mx-auto my-6 p-6 rounded-lg text-brand-dark">
+      <h2 className="text-3xl font-bold mb-10 text-center">
+        Vos documents publiques
+      </h2>
+
+      <div className="space-y-10">
+        <div className="flex gap-8 justify-center flex-wrap">
+          {/* LOGO */}
+          <div className="flex flex-col items-center">
+            <h3 className="text-2xl font-semibold mb-4">Logo</h3>
+            {documents.LOGO[0] ? (
+              <div className="space-y-3 flex flex-col items-center">
+                <DocumentPreviewAndDelete
+                  document={documents.LOGO[0]}
+                  onDeleteSuccess={fetchDocuments}
+                />
+                <p className="text-sm italic text-center max-w-xs">
+                  Supprimez le logo pour en télécharger un nouveau.
+                </p>
+              </div>
+            ) : (
+              <DocumentUploadButton
+                category="LOGO"
+                accept="image/png, image/jpeg, image/webp"
+                label="Ajouter votre logo"
+                onUploadSuccess={fetchDocuments}
+              />
+            )}
+          </div>
+
+          {/* COVER PHOTO */}
+          <div className="flex flex-col items-center">
+            <h3 className="text-2xl font-semibold mb-4">Photo de couverture</h3>
+            {documents.COVER_PHOTO[0] ? (
+              <div className="space-y-3 flex flex-col items-center">
+                <DocumentPreviewAndDelete
+                  document={documents.COVER_PHOTO[0]}
+                  onDeleteSuccess={fetchDocuments}
+                />
+                <p className="text-sm italic text-center max-w-xs">
+                  Supprimez la photo pour en télécharger une nouvelle.
+                </p>
+              </div>
+            ) : (
+              <DocumentUploadButton
+                category="COVER_PHOTO"
+                accept="image/*"
+                label="Ajouter votre photo de couverture"
+                onUploadSuccess={fetchDocuments}
+              />
+            )}
+          </div>
+
+          {/* CATALOG (Supplier only) */}
+          {user?.establishmentType === EstablishmentType.SUPPLIER && (
+            <div className="flex flex-col items-center w-full md:w-auto">
+              <h3 className="text-2xl font-semibold mb-4">Catalogue</h3>
+              {documents.CATALOG[0] ? (
+                <div className="space-y-3 flex flex-col items-center">
+                  <DocumentPreviewAndDelete
+                    document={documents.CATALOG[0]}
+                    onDeleteSuccess={fetchDocuments}
+                  />
+                  <p className="text-sm italic text-center max-w-xs">
+                    Supprimez le catalogue pour en télécharger un nouveau.
+                  </p>
+                </div>
+              ) : (
+                <DocumentUploadButton
+                  category="CATALOG"
+                  accept="application/pdf"
+                  label="Ajouter votre catalogue (PDF)"
+                  onUploadSuccess={fetchDocuments}
+                />
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* GALLERY (Supplier only) */}
+        {user?.establishmentType === EstablishmentType.SUPPLIER && (
+          <div className="flex flex-col items-center">
+            <h3 className="text-2xl font-semibold mb-4">
+              Galerie photos ({documents.GALLERY_PHOTO.length}/6)
+            </h3>
+
+            {documents.GALLERY_PHOTO.length > 0 && (
+              <div className="flex flex-wrap gap-6 flex-col sm:flex-row mb-4 max-w-4xl">
+                {documents.GALLERY_PHOTO.map((doc) => (
+                  <DocumentPreviewAndDelete
+                    key={doc.id}
+                    document={doc}
+                    onDeleteSuccess={fetchDocuments}
+                  />
+                ))}
+              </div>
+            )}
+
+            {documents.GALLERY_PHOTO.length < 6 ? (
+              <DocumentUploadButton
+                category="GALLERY_PHOTO"
+                accept="image/*"
+                label="Ajouter une photo"
+                onUploadSuccess={fetchDocuments}
+              />
+            ) : (
+              <p className="text-sm italic text-center max-w-md">
+                Galerie complète (6 photos maximum). Supprimez une photo pour en
+                ajouter une nouvelle.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default DocumentsList;

--- a/frontend/src/pages/restaurant/DashboardPage.tsx
+++ b/frontend/src/pages/restaurant/DashboardPage.tsx
@@ -1,9 +1,11 @@
 import LogOutButton from "../../components/auth/LogOutButton";
+import DocumentsList from "../../components/documents/DocumentsList";
 
 function DashboardPage() {
   return (
     <div>
       <h1>Dashboard</h1>
+      <DocumentsList />
       <LogOutButton />
     </div>
   );

--- a/frontend/src/pages/supplier/DashboardPage.tsx
+++ b/frontend/src/pages/supplier/DashboardPage.tsx
@@ -1,9 +1,11 @@
 import LogOutButton from "../../components/auth/LogOutButton";
+import DocumentsList from "../../components/documents/DocumentsList";
 
 function DashboardPage() {
   return (
     <div>
       <h1>Dashboard</h1>
+      <DocumentsList />
       <LogOutButton />
     </div>
   );

--- a/frontend/src/types/documents.types.ts
+++ b/frontend/src/types/documents.types.ts
@@ -1,0 +1,40 @@
+export const DocumentCategory = {
+  LOGO: "LOGO",
+  COVER_PHOTO: "COVER_PHOTO",
+  CATALOG: "CATALOG",
+  GALLERY_PHOTO: "GALLERY_PHOTO",
+} as const;
+
+export type DocumentCategory =
+  (typeof DocumentCategory)[keyof typeof DocumentCategory];
+
+export type FileResponse = {
+  id: number;
+  originalFilename: string;
+  mimeType: string;
+  size: number;
+  url: string;
+};
+
+export type DocumentItem = {
+  id: number;
+  file: FileResponse;
+};
+
+export type GroupedDocuments = {
+  LOGO: DocumentItem[];
+  COVER_PHOTO: DocumentItem[];
+  CATALOG: DocumentItem[];
+  GALLERY_PHOTO: DocumentItem[];
+};
+
+export type DocumentResponse = {
+  id: number;
+  category: DocumentCategory;
+  file: FileResponse;
+};
+
+export type UploadDocumentDto = {
+  file: File;
+  category: DocumentCategory;
+};


### PR DESCRIPTION
This PR introduces the document management feature for establishments, allowing users to upload, view and delete their public documents.

## Features

### Document management
- Upload documents by category:
  - Logo
  - Cover photo
  - Catalog (supplier only)
  - Gallery photos (max 6)
- Delete documents with confirmation
- Preview documents:
  - Image preview (logo, cover, gallery)
  - PDF access via external link

## Components

- DocumentsList
  - Main container fetching and displaying documents
  - Handles category logic and conditional rendering

- DocumentCard
  - Displays a document (image or PDF)
  - Handles delete action with confirmation UI

- DocumentUploadButton
  - Handles file selection and upload
  - Validates file size (max 20MB) and MIME types
  - Displays helper messages and upload state

## API Integration

- uploadDocument(file, category)
  - Multipart upload with 30s timeout

- getDocuments()
  - Fetch documents grouped by category

- deleteDocument(documentId)
  - Delete document by ID

## Types

- DocumentCategory
- DocumentItem
- GroupedDocuments
- DocumentResponse

## UI / UX

- Toast notifications for success and error states
- Upload validation feedback (size & format)
- Conditional rendering based on establishment type (supplier / restaurant)
- Gallery limit (max 6 images)
