### PR TITLE
Add CurrentEstablishmentUser decorator to improve typing

### DIFF
--- a/backend/src/common/decorators/current-establishment-user.decorator.ts
+++ b/backend/src/common/decorators/current-establishment-user.decorator.ts
@@ -14,7 +14,7 @@ export const CurrentEstablishmentUser = createParamDecorator(
 
     const user = request.user;
     if (!user) {
-      throw new Error('User not authenticated');
+      throw new ForbiddenException('User not authenticated');
     }
     if (!user.establishmentId || !user.establishmentType) {
       throw new ForbiddenException('User must have an establishment');

--- a/backend/src/common/decorators/current-establishment-user.decorator.ts
+++ b/backend/src/common/decorators/current-establishment-user.decorator.ts
@@ -1,0 +1,25 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { UserWithEstablishment } from '../types/user-with-establishment.type';
+import { AuthenticatedUser } from '../../auth/interfaces/authenticated-user.interface';
+
+export const CurrentEstablishmentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): UserWithEstablishment => {
+    const request: Express.Request & { user?: AuthenticatedUser } = ctx
+      .switchToHttp()
+      .getRequest();
+
+    const user = request.user;
+    if (!user) {
+      throw new Error('User not authenticated');
+    }
+    if (!user.establishmentId || !user.establishmentType) {
+      throw new ForbiddenException('User must have an establishment');
+    }
+
+    return user as UserWithEstablishment;
+  },
+);

--- a/backend/src/common/guards/establishment.guard.ts
+++ b/backend/src/common/guards/establishment.guard.ts
@@ -13,9 +13,14 @@ export class EstablishmentGuard implements CanActivate {
       .switchToHttp()
       .getRequest<Request & { user: AuthenticatedUser }>();
 
-    if (!request.user.establishmentId || !request.user.establishmentType) {
+    const user = request.user;
+    if (!user) {
+      throw new ForbiddenException('User not authenticated');
+    }
+    if (!user.establishmentId || !user.establishmentType) {
       throw new ForbiddenException('You must create an establishment first');
     }
+
     return true;
   }
 }

--- a/backend/src/common/types/user-with-establishment.type.ts
+++ b/backend/src/common/types/user-with-establishment.type.ts
@@ -1,0 +1,7 @@
+import { AuthenticatedUser } from '../../auth/interfaces/authenticated-user.interface';
+import { EstablishmentType } from '../../establishments/enums/establishment-type.enum';
+
+export type UserWithEstablishment = AuthenticatedUser & {
+  establishmentId: number;
+  establishmentType: EstablishmentType;
+};

--- a/backend/src/conversations/conversations.controller.ts
+++ b/backend/src/conversations/conversations.controller.ts
@@ -18,14 +18,14 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { CurrentUser } from '../common/decorators/current-user.decorator';
-import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
 import { SendMessageDto } from './dto/send-message.dto';
 import { EstablishmentGuard } from '../common/guards/establishment.guard';
 import { Conversation } from './entities/conversation.entity';
 import { ConversationResponseDto } from './dto/conversation-response.dto';
 import { UnreadCountResponseDto } from './dto/unread-count-response.dto';
 import { MessageResponseDto } from './dto/message-response.dto';
+import { CurrentEstablishmentUser } from 'src/common/decorators/current-establishment-user.decorator';
+import { type UserWithEstablishment } from 'src/common/types/user-with-establishment.type';
 
 @ApiTags('conversations')
 @ApiBearerAuth()
@@ -43,11 +43,11 @@ export class ConversationsController {
   @ApiNotFoundResponse({ description: 'Supplier not found' })
   createConversation(
     @Body() createConversationDto: CreateConversationDto,
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
   ): Promise<Conversation> {
     return this.conversationsService.createConversation(
-      user.establishmentId!,
-      user.establishmentType!,
+      user.establishmentId,
+      user.establishmentType,
       createConversationDto.supplierId,
     );
   }
@@ -62,12 +62,12 @@ export class ConversationsController {
   sendMessage(
     @Param('id', ParseIntPipe) conversationId: number,
     @Body() sendMessageDto: SendMessageDto,
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
   ): Promise<MessageResponseDto> {
     return this.conversationsService.sendMessage(
       conversationId,
-      user.establishmentId!,
-      user.establishmentType!,
+      user.establishmentId,
+      user.establishmentType,
       sendMessageDto.content,
     );
   }
@@ -76,11 +76,11 @@ export class ConversationsController {
   @ApiOperation({ summary: 'Get all conversations' })
   @ApiOkResponse({ type: [ConversationResponseDto] })
   getConversations(
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
   ): Promise<ConversationResponseDto[]> {
     return this.conversationsService.getConversations(
-      user.establishmentId!,
-      user.establishmentType!,
+      user.establishmentId,
+      user.establishmentType,
     );
   }
 
@@ -88,11 +88,11 @@ export class ConversationsController {
   @ApiOperation({ summary: 'Get total unread messages count' })
   @ApiOkResponse({ type: UnreadCountResponseDto })
   getUnreadCount(
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
   ): Promise<UnreadCountResponseDto> {
     return this.conversationsService.getTotalUnreadCount(
-      user.establishmentId!,
-      user.establishmentType!,
+      user.establishmentId,
+      user.establishmentType,
     );
   }
 
@@ -105,12 +105,12 @@ export class ConversationsController {
   @ApiNotFoundResponse({ description: 'Conversation not found' })
   getConversationMessages(
     @Param('id', ParseIntPipe) conversationId: number,
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
   ): Promise<MessageResponseDto[]> {
     return this.conversationsService.getConversationMessages(
       conversationId,
-      user.establishmentId!,
-      user.establishmentType!,
+      user.establishmentId,
+      user.establishmentType,
     );
   }
 }

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -14,8 +14,6 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
-import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { CreateDocumentDto } from '../documents/dto/create-document.dto';
 import {
   ApiBadRequestResponse,
@@ -39,6 +37,8 @@ import { DocumentResponseDto } from '../documents/dto/document-response.dto';
 import { DocumentsService } from './documents.service';
 import { GroupedDocumentsResponseDto } from './dto/grouped-documents-response.dto';
 import { EstablishmentGuard } from 'src/common/guards/establishment.guard';
+import { CurrentEstablishmentUser } from 'src/common/decorators/current-establishment-user.decorator';
+import { type UserWithEstablishment } from 'src/common/types/user-with-establishment.type';
 
 @ApiTags('documents')
 @ApiBearerAuth()
@@ -78,7 +78,7 @@ export class DocumentsController {
   })
   @UseInterceptors(FileInterceptor('file', multerPublicOptions))
   async upload(
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
     @UploadedFile(
       new ParseFilePipeBuilder()
         .addMaxSizeValidator({
@@ -90,9 +90,9 @@ export class DocumentsController {
     )
     file: Express.Multer.File,
     @Body() dto: CreateDocumentDto,
-  ) {
+  ): Promise<DocumentResponseDto> {
     return this.documentsService.upload(
-      user.establishmentId!,
+      user.establishmentId,
       user.establishmentType,
       file,
       dto.category,
@@ -117,16 +117,16 @@ export class DocumentsController {
     description: 'You must create an establishment before managing documents',
   })
   async findAll(
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
     @Query('category') category?: DocumentCategory,
   ): Promise<GroupedDocumentsResponseDto | DocumentResponseDto[]> {
     if (category) {
       return this.documentsService.findByCategory(
-        user.establishmentId!,
+        user.establishmentId,
         category,
       );
     }
-    return this.documentsService.findAllByEstablishment(user.establishmentId!);
+    return this.documentsService.findAllByEstablishment(user.establishmentId);
   }
 
   @Delete(':id')
@@ -138,9 +138,9 @@ export class DocumentsController {
     description: 'You must create an establishment before managing documents',
   })
   async delete(
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
     @Param('id', ParseIntPipe) documentId: number,
-  ) {
-    return this.documentsService.delete(documentId, user.establishmentId!);
+  ): Promise<void> {
+    return this.documentsService.delete(documentId, user.establishmentId);
   }
 }

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -27,12 +27,12 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { EstablishmentGuard } from '../common/guards/establishment.guard';
-import { CurrentUser } from '../common/decorators/current-user.decorator';
-import { type AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
 import { ReviewResponseDto } from './dto/review-response.dto';
 import { ReplyReviewDto } from './dto/reply-review.dto';
 import { SupplierReviewsResponseDto } from './dto/supplier-reviews-response.dto';
 import { Public } from '../common/decorators/public.decorator';
+import { CurrentEstablishmentUser } from 'src/common/decorators/current-establishment-user.decorator';
+import { type UserWithEstablishment } from 'src/common/types/user-with-establishment.type';
 
 @ApiTags('reviews')
 @ApiBearerAuth()
@@ -51,11 +51,11 @@ export class ReviewsController {
   })
   createReview(
     @Body() createReviewDto: CreateReviewDto,
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
   ): Promise<ReviewResponseDto> {
     return this.reviewsService.createReview(
-      user.establishmentId!,
-      user.establishmentType!,
+      user.establishmentId,
+      user.establishmentType,
       createReviewDto,
     );
   }
@@ -82,12 +82,12 @@ export class ReviewsController {
   replyToReview(
     @Param('id', ParseIntPipe) reviewId: number,
     @Body() replyReviewDto: ReplyReviewDto,
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
   ): Promise<ReviewResponseDto> {
     return this.reviewsService.replyToReview(
       reviewId,
-      user.establishmentId!,
-      user.establishmentType!,
+      user.establishmentId,
+      user.establishmentType,
       replyReviewDto,
     );
   }
@@ -100,12 +100,12 @@ export class ReviewsController {
   @ApiNotFoundResponse({ description: 'Review not found' })
   deleteReview(
     @Param('id', ParseIntPipe) reviewId: number,
-    @CurrentUser() user: AuthenticatedUser,
+    @CurrentEstablishmentUser() user: UserWithEstablishment,
   ): Promise<void> {
     return this.reviewsService.deleteReview(
       reviewId,
-      user.establishmentId!,
-      user.establishmentType!,
+      user.establishmentId,
+      user.establishmentType,
     );
   }
 }


### PR DESCRIPTION
This PR introduces CurrentEstablishmentUser decorator

## Changes

- Added `CurrentEstablishmentUser` decorator
- Added `UserWithEstablishment` type
- Replaced `@CurrentUser` in controllers where an establishment is required
- Removed non-null assertions (`!`) on `establishmentId` and `establishmentType`