### PR TITLE
Fix: respect @Public in guards and fix Swagger auth display - Issue #56

### DIFF
--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -2,11 +2,11 @@ import { IsEmail, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
-  @ApiProperty({ example: 'john@restaurant.com' })
+  @ApiProperty({ example: 'contact@legourmet-lyon.com' })
   @IsEmail()
   email: string;
 
-  @ApiProperty({ example: 'password123!' })
+  @ApiProperty({ example: 'Password123!' })
   @IsString()
   password: string;
 }

--- a/backend/src/common/guards/establishment.guard.ts
+++ b/backend/src/common/guards/establishment.guard.ts
@@ -4,11 +4,23 @@ import {
   ForbiddenException,
   Injectable,
 } from '@nestjs/common';
-import { AuthenticatedUser } from 'src/auth/interfaces/authenticated-user.interface';
+import { Reflector } from '@nestjs/core';
+import { AuthenticatedUser } from '../../auth/interfaces/authenticated-user.interface';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
 export class EstablishmentGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
   canActivate(context: ExecutionContext): boolean {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+
     const request = context
       .switchToHttp()
       .getRequest<Request & { user: AuthenticatedUser }>();

--- a/backend/src/establishments/dto/establishment-details.dto.ts
+++ b/backend/src/establishments/dto/establishment-details.dto.ts
@@ -74,18 +74,20 @@ export class EstablishmentDetailsDto {
   coverPhotoUrl?: string | null;
 
   @ApiPropertyOptional({
-    example:
-      'https://le-bon-fournisseur-files.s3.eu-west-3.amazonaws.com/public/catalog.pdf',
-    nullable: true,
+    example: [
+      'https://le-bon-fournisseur-files.s3.eu-west-3.amazonaws.com/public/catalog1.pdf',
+      'https://le-bon-fournisseur-files.s3.eu-west-3.amazonaws.com/public/catalog2.pdf',
+    ],
+    type: [String],
   })
-  catalogUrl?: string | null;
+  catalogUrls?: string[];
 
   @ApiPropertyOptional({
     example: [
       'https://le-bon-fournisseur-files.s3.eu-west-3.amazonaws.com/public/photo1.jpg',
       'https://le-bon-fournisseur-files.s3.eu-west-3.amazonaws.com/public/photo2.jpg',
     ],
-    required: false,
+    type: [String],
   })
   galleryPhotos?: string[];
 }

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -35,13 +35,13 @@ import { CurrentEstablishmentUser } from 'src/common/decorators/current-establis
 import { type UserWithEstablishment } from 'src/common/types/user-with-establishment.type';
 
 @ApiTags('reviews')
-@ApiBearerAuth()
 @UseGuards(EstablishmentGuard)
 @Controller('reviews')
 export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) {}
 
   @Post()
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Create a review for a supplier' })
   @ApiCreatedResponse({ type: ReviewResponseDto })
   @ApiForbiddenResponse({ description: 'Only restaurants can create reviews' })
@@ -60,11 +60,11 @@ export class ReviewsController {
     );
   }
 
+  @Public()
   @Get()
   @ApiOperation({ summary: 'Get all reviews for a supplier' })
   @ApiOkResponse({ type: SupplierReviewsResponseDto })
   @ApiQuery({ name: 'supplierId', type: Number, required: true })
-  @Public()
   getSupplierReviews(
     @Query('supplierId', ParseIntPipe) supplierId: number,
   ): Promise<SupplierReviewsResponseDto> {
@@ -72,6 +72,7 @@ export class ReviewsController {
   }
 
   @Patch(':id/reply')
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Reply to a review' })
   @ApiOkResponse({ type: ReviewResponseDto })
   @ApiForbiddenResponse({ description: 'Only suppliers can reply to reviews' })
@@ -93,6 +94,7 @@ export class ReviewsController {
   }
 
   @Delete(':id')
+  @ApiBearerAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a review' })
   @ApiNoContentResponse({ description: 'Review deleted successfully' })

--- a/backend/src/suppliers/dto/supplier-details.dto.ts
+++ b/backend/src/suppliers/dto/supplier-details.dto.ts
@@ -40,7 +40,7 @@ export class SupplierDetailDto extends SupplierListItemDto {
     ],
     type: [String],
   })
-  catalogs?: string[];
+  catalogUrls?: string[];
 
   @ApiPropertyOptional({
     example: [

--- a/backend/src/suppliers/suppliers.controller.ts
+++ b/backend/src/suppliers/suppliers.controller.ts
@@ -31,7 +31,6 @@ import type { AuthenticatedUser } from 'src/auth/interfaces/authenticated-user.i
 import { Public } from 'src/common/decorators/public.decorator';
 
 @ApiTags('suppliers')
-@ApiBearerAuth()
 @Controller('suppliers')
 export class SuppliersController {
   constructor(private readonly suppliersService: SuppliersService) {}
@@ -56,6 +55,7 @@ export class SuppliersController {
 
   // POST /supplier
   @Post()
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Create supplierAttributes' })
   @ApiCreatedResponse()
   create(
@@ -76,6 +76,7 @@ export class SuppliersController {
 
   // GET /supplier/:id/stats
   @Get(':id/stats')
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get a supplier by id and see all of the stats' })
   @ApiOkResponse({ type: SupplierStatsDto })
   findStats(@Param('id') id: string): Promise<SupplierStatsDto> {
@@ -93,6 +94,7 @@ export class SuppliersController {
 
   // PATCH /suppliers/:id
   @Patch(':id')
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Make changes on a supplier' })
   @ApiOkResponse({ type: SupplierDetailDto })
   update(
@@ -105,6 +107,7 @@ export class SuppliersController {
 
   // DELETE /supplier/:id
   @Delete(':id')
+  @ApiBearerAuth()
   @HttpCode(204)
   @ApiOperation({ summary: 'Delete a supplier' })
   @ApiNoContentResponse()

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -3,7 +3,7 @@ import { UserRole } from '../enums/user-role.enum';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateUserDto {
-  @ApiProperty({ example: 'john@restaurant.com' })
+  @ApiProperty({ example: 'contact@legourmet-lyon.com' })
   @IsEmail()
   email: string;
 
@@ -21,11 +21,11 @@ export class CreateUserDto {
   })
   password: string;
 
-  @ApiProperty({ example: 'Doe' })
+  @ApiProperty({ example: 'Dubois' })
   @IsString()
   lastName: string;
 
-  @ApiProperty({ example: 'John' })
+  @ApiProperty({ example: 'Pierre' })
   @IsString()
   firstName: string;
 

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -3,7 +3,7 @@ import { UserRole } from '../enums/user-role.enum';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateUserDto {
-  @ApiProperty({ example: 'contact@legourmet-lyon.com' })
+  @ApiProperty({ example: 'john@restaurant.com' })
   @IsEmail()
   email: string;
 
@@ -21,11 +21,11 @@ export class CreateUserDto {
   })
   password: string;
 
-  @ApiProperty({ example: 'Dubois' })
+  @ApiProperty({ example: 'Doe' })
   @IsString()
   lastName: string;
 
-  @ApiProperty({ example: 'Pierre' })
+  @ApiProperty({ example: 'John' })
   @IsString()
   firstName: string;
 


### PR DESCRIPTION
This PR fix inconsistency between `@Public()` routes and establishment guard behavior, and correct Swagger auth display.

## Changes

- `EstablishmentGuard` now correctly respects `@Public()` decorator
- Public routes are no longer blocked by authentication/establishment checks
- Swagger `@ApiBearerAuth()` is now only used on protected routes
