### PR TITLE
Jest setup and base unit tests - Issue #59

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,67 +6,72 @@ on:
   # Quand tu PUSH du code sur ces branches :
   push:
     branches:
-      - main          # Si tu push sur main
-      - develop       # Si tu push sur develop
-      - 'feature/**'  # Si tu push sur n'importe quelle branche feature/xxx
-      - 'release/**'  # Si tu push sur release/xxx
-      - 'hotfix/**'   # Si tu push sur hotfix/xxx
-  
+      - main # Si tu push sur main
+      - develop # Si tu push sur develop
+      - "feature/**" # Si tu push sur n'importe quelle branche feature/xxx
+      - "release/**" # Si tu push sur release/xxx
+      - "hotfix/**" # Si tu push sur hotfix/xxx
+
   # Quand quelqu'un crée une PULL REQUEST vers ces branches :
   pull_request:
     branches:
-      - main          # PR vers main (depuis release ou hotfix)
-      - develop       # PR vers develop (depuis feature)
+      - main # PR vers main (depuis release ou hotfix)
+      - develop # PR vers develop (depuis feature)
 
 # LES TÂCHES à exécuter (jobs)
 jobs:
   # Job appelé "test-and-build"
   test-and-build:
-    name: Tests & Build              # Nom affiché dans GitHub
-    runs-on: ubuntu-latest           # Sur quelle machine ça tourne (Ubuntu Linux)
+    name: Tests & Build # Nom affiché dans GitHub
+    runs-on: ubuntu-latest # Sur quelle machine ça tourne (Ubuntu Linux)
 
     # LES ÉTAPES (steps) exécutées une par une
     steps:
       # ÉTAPE 1 : Télécharge ton code depuis GitHub
       - name: Checkout code
-        uses: actions/checkout@v4    # Action GitHub officielle pour récupérer le code
-      
+        uses: actions/checkout@v4 # Action GitHub officielle pour récupérer le code
+
       # ÉTAPE 2 : Installe Node.js version 20
       - name: Setup Node.js
-        uses: actions/setup-node@v4  # Action GitHub pour installer Node.js
+        uses: actions/setup-node@v4 # Action GitHub pour installer Node.js
         with:
-          node-version: '20'         # Version de Node.js
-      
+          node-version: "20" # Version de Node.js
+
       # ========== FRONTEND ==========
-      
+
       # ÉTAPE 3 : Installe les dépendances du frontend
       - name: Install Frontend
-        working-directory: ./frontend  # Va dans le dossier frontend/
-        run: npm ci                    # Commande : npm ci (install rapide et sûr)
-      
+        working-directory: ./frontend # Va dans le dossier frontend/
+        run: npm ci # Commande : npm ci (install rapide et sûr)
+
       # ÉTAPE 4 : Vérifie le code frontend avec ESLint
       - name: Lint Frontend
         working-directory: ./frontend
-        run: npm run lint              # Commande : npm run lint (vérifie erreurs syntaxe)
-      
+        run: npm run lint # Commande : npm run lint (vérifie erreurs syntaxe)
+
       # ÉTAPE 5 : Compile le frontend
       - name: Build Frontend
         working-directory: ./frontend
-        run: npm run build             # Commande : npm run build (compile TypeScript → JS)
-      
+        run: npm run build # Commande : npm run build (compile TypeScript → JS)
+
       # ========== BACKEND ==========
-      
+
       # ÉTAPE 6 : Installe les dépendances du backend
       - name: Install Backend
         working-directory: ./backend
         run: npm ci
-      
+
       # ÉTAPE 7 : Vérifie le code backend avec ESLint
       - name: Lint Backend
         working-directory: ./backend
         run: npm run lint
-      
-      # ÉTAPE 8 : Compile le backend
+
+      # ÉTAPE 8 : Lance les tests backend
+      - name: Test Backend
+        working-directory: ./backend
+        run: npm run test
+
+      # ÉTAPE 9 : Compile le backend
       - name: Build Backend
         working-directory: ./backend
         run: npm run build

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -55,7 +55,7 @@
         "ts-loader": "^9.5.2",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.21.0",
-        "typescript": "^6.0.2",
+        "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
       }
     },
@@ -3441,20 +3441,6 @@
         "@swc/core": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@nestjs/common": {
@@ -12030,9 +12016,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -75,7 +75,7 @@
     "ts-loader": "^9.5.2",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.2",
+    "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
   },
   "jest": {
@@ -93,6 +93,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -8,7 +8,12 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [AuthService],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: { register: jest.fn(), login: jest.fn() },
+        },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,12 +1,30 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { UsersService } from 'src/users/users.service';
+import { JwtService } from '@nestjs/jwt/dist/jwt.service';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        {
+          provide: UsersService,
+          useValue: {
+            create: jest.fn(),
+            updateLastLogin: jest.fn(),
+            findByEmailWithEstablishment: jest.fn(),
+          },
+        },
+        {
+          provide: JwtService,
+          useValue: {
+            sign: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);

--- a/backend/src/conversations/conversations.controller.spec.ts
+++ b/backend/src/conversations/conversations.controller.spec.ts
@@ -8,7 +8,18 @@ describe('ConversationsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ConversationsController],
-      providers: [ConversationsService],
+      providers: [
+        {
+          provide: ConversationsService,
+          useValue: {
+            createConversation: jest.fn(),
+            sendMessage: jest.fn(),
+            getConversations: jest.fn(),
+            getTotalUnreadCount: jest.fn(),
+            getConversationMessages: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<ConversationsController>(ConversationsController);

--- a/backend/src/conversations/conversations.service.spec.ts
+++ b/backend/src/conversations/conversations.service.spec.ts
@@ -1,12 +1,26 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConversationsService } from './conversations.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Conversation } from './entities/conversation.entity';
+import { Message } from './entities/message.entity';
+import { Establishment } from 'src/establishments/entities/establishment.entity';
+import { FilesService } from 'src/files/files.service';
 
 describe('ConversationsService', () => {
   let service: ConversationsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ConversationsService],
+      providers: [
+        ConversationsService,
+        { provide: getRepositoryToken(Conversation), useValue: {} },
+        { provide: getRepositoryToken(Message), useValue: {} },
+        { provide: getRepositoryToken(Establishment), useValue: {} },
+        {
+          provide: FilesService,
+          useValue: { create: jest.fn(), getPrivateFileSignedUrl: jest.fn() },
+        },
+      ],
     }).compile();
 
     service = module.get<ConversationsService>(ConversationsService);

--- a/backend/src/conversations/message-attachments.controller.spec.ts
+++ b/backend/src/conversations/message-attachments.controller.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessageAttachmentsController } from './message-attachments.controller';
+import { ConversationsService } from './conversations.service';
+
+describe('MessageAttachmentsController', () => {
+  let controller: MessageAttachmentsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MessageAttachmentsController],
+      providers: [
+        {
+          provide: ConversationsService,
+          useValue: {
+            sendAttachment: jest.fn(),
+            getAttachmentSignedUrl: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<MessageAttachmentsController>(
+      MessageAttachmentsController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/documents/documents.controller.spec.ts
+++ b/backend/src/documents/documents.controller.spec.ts
@@ -8,7 +8,17 @@ describe('DocumentsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DocumentsController],
-      providers: [DocumentsService],
+      providers: [
+        {
+          provide: DocumentsService,
+          useValue: {
+            upload: jest.fn(),
+            findAllByEstablishment: jest.fn(),
+            findByCategory: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<DocumentsController>(DocumentsController);

--- a/backend/src/documents/documents.service.spec.ts
+++ b/backend/src/documents/documents.service.spec.ts
@@ -1,12 +1,26 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DocumentsService } from './documents.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { FilesService } from 'src/files/files.service';
+import { Document } from './entities/document.entity';
 
 describe('DocumentsService', () => {
   let service: DocumentsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DocumentsService],
+      providers: [
+        DocumentsService,
+        { provide: getRepositoryToken(Document), useValue: {} },
+        {
+          provide: FilesService,
+          useValue: {
+            create: jest.fn(),
+            getPublicFileUrl: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<DocumentsService>(DocumentsService);

--- a/backend/src/establishments/establishments.controller.spec.ts
+++ b/backend/src/establishments/establishments.controller.spec.ts
@@ -8,7 +8,18 @@ describe('EstablishmentsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [EstablishmentsController],
-      providers: [EstablishmentsService],
+      providers: [
+        {
+          provide: EstablishmentsService,
+          useValue: {
+            create: jest.fn(),
+            findPreview: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<EstablishmentsController>(EstablishmentsController);

--- a/backend/src/establishments/establishments.service.spec.ts
+++ b/backend/src/establishments/establishments.service.spec.ts
@@ -1,12 +1,26 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { EstablishmentsService } from './establishments.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Establishment } from './entities/establishment.entity';
+import { User } from 'src/users/entities/user.entity';
+import { DocumentsService } from 'src/documents/documents.service';
 
 describe('EstablishmentsService', () => {
   let service: EstablishmentsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [EstablishmentsService],
+      providers: [
+        EstablishmentsService,
+        { provide: getRepositoryToken(Establishment), useValue: {} },
+        { provide: getRepositoryToken(User), useValue: {} },
+        {
+          provide: DocumentsService,
+          useValue: {
+            getAllDocumentUrls: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<EstablishmentsService>(EstablishmentsService);

--- a/backend/src/favorites/favorites.controller.spec.ts
+++ b/backend/src/favorites/favorites.controller.spec.ts
@@ -8,7 +8,16 @@ describe('FavoritesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FavoritesController],
-      providers: [FavoritesService],
+      providers: [
+        {
+          provide: FavoritesService,
+          useValue: {
+            create: jest.fn(),
+            getRestaurantFavorites: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<FavoritesController>(FavoritesController);

--- a/backend/src/favorites/favorites.service.spec.ts
+++ b/backend/src/favorites/favorites.service.spec.ts
@@ -1,12 +1,26 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FavoritesService } from './favorites.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { Favorite } from './entities/favorite.entity';
+import { Establishment } from 'src/establishments/entities/establishment.entity';
 
 describe('FavoritesService', () => {
   let service: FavoritesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FavoritesService],
+      providers: [
+        FavoritesService,
+        {
+          provide: getRepositoryToken(Favorite),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(Establishment),
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<FavoritesService>(FavoritesService);

--- a/backend/src/files/files.service.spec.ts
+++ b/backend/src/files/files.service.spec.ts
@@ -1,12 +1,30 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FilesService } from './files.service';
+import { S3Service } from './s3.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { StoredFile } from './entities/stored-file.entity';
 
 describe('FilesService', () => {
   let service: FilesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FilesService],
+      providers: [
+        FilesService,
+        {
+          provide: S3Service,
+          useValue: {
+            uploadFile: jest.fn(),
+            deleteFile: jest.fn(),
+            getPublicUrl: jest.fn(),
+            getSignedUrl: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(StoredFile),
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<FilesService>(FilesService);

--- a/backend/src/reviews/reviews.controller.spec.ts
+++ b/backend/src/reviews/reviews.controller.spec.ts
@@ -8,7 +8,17 @@ describe('ReviewsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ReviewsController],
-      providers: [ReviewsService],
+      providers: [
+        {
+          provide: ReviewsService,
+          useValue: {
+            createReview: jest.fn(),
+            getSupplierReviews: jest.fn(),
+            replyToReview: jest.fn(),
+            deleteReview: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<ReviewsController>(ReviewsController);

--- a/backend/src/reviews/reviews.service.spec.ts
+++ b/backend/src/reviews/reviews.service.spec.ts
@@ -1,12 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ReviewsService } from './reviews.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Review } from './entities/review.entity';
+import { Establishment } from 'src/establishments/entities/establishment.entity';
 
 describe('ReviewsService', () => {
   let service: ReviewsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ReviewsService],
+      providers: [
+        ReviewsService,
+        {
+          provide: getRepositoryToken(Review),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(Establishment),
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<ReviewsService>(ReviewsService);

--- a/backend/src/suppliers/suppliers.controller.spec.ts
+++ b/backend/src/suppliers/suppliers.controller.spec.ts
@@ -8,7 +8,21 @@ describe('SuppliersController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SuppliersController],
-      providers: [SuppliersService],
+      providers: [
+        {
+          provide: SuppliersService,
+          useValue: {
+            findAllLabels: jest.fn(),
+            findAllCategories: jest.fn(),
+            create: jest.fn(),
+            findAll: jest.fn(),
+            findStats: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<SuppliersController>(SuppliersController);

--- a/backend/src/suppliers/suppliers.service.spec.ts
+++ b/backend/src/suppliers/suppliers.service.spec.ts
@@ -1,12 +1,47 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SuppliersService } from './suppliers.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SupplierAttributes } from './entities/supplier-attributes.entity';
+import { Label } from './entities/label.entity';
+import { ProductCategory } from './entities/product-category.entity';
+import { Favorite } from 'src/favorites/entities/favorite.entity';
+import { Review } from 'src/reviews/entities/review.entity';
+import { DocumentsService } from 'src/documents/documents.service';
 
 describe('SuppliersService', () => {
   let service: SuppliersService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SuppliersService],
+      providers: [
+        SuppliersService,
+        {
+          provide: getRepositoryToken(SupplierAttributes),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(Label),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(ProductCategory),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(Favorite),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(Review),
+          useValue: {},
+        },
+        {
+          provide: DocumentsService,
+          useValue: {
+            getAllDocumentUrls: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<SuppliersService>(SuppliersService);

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -8,7 +8,16 @@ describe('UsersController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
-      providers: [UsersService],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: {
+            getProfile: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<UsersController>(UsersController);

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,12 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { ConfigService } from '@nestjs/config';
 
 describe('UsersService', () => {
   let service: UsersService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UsersService],
+      providers: [
+        UsersService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: {},
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "paths": {
+      "src/*": ["./src/*"]
+    },
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "resolvePackageJsonExports": true,


### PR DESCRIPTION
This PR fixes the TypeScript and Jest configuration and updates all base unit tests.

## Changes

### Config
- Downgrade TypeScript to 5.7.3 (ts-jest compatibility)
- Add `paths` mapping in `tsconfig.json` to resolve `src/...` imports
- Add `moduleNameMapper` in Jest config to align with tsconfig
- Add `npm run test` step in CI pipeline

### Tests
- Fix all auto-generated `.spec.ts` files with properly mocked dependencies
- Create `message-attachments.controller.spec.ts`
- All tests passing 