### PR TITLE
Fix SPA routing on Vercel and update CI to Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
     steps:
       # ÉTAPE 1 : Télécharge ton code depuis GitHub
       - name: Checkout code
-        uses: actions/checkout@v4 # Action GitHub officielle pour récupérer le code
+        uses: actions/checkout@v5 # Action GitHub officielle pour récupérer le code
 
-      # ÉTAPE 2 : Installe Node.js version 20
+      # ÉTAPE 2 : Installe Node.js version 22
       - name: Setup Node.js
-        uses: actions/setup-node@v4 # Action GitHub pour installer Node.js
+        uses: actions/setup-node@v5 # Action GitHub pour installer Node.js
         with:
-          node-version: "20" # Version de Node.js
+          node-version: "22" # Version de Node.js
 
       # ========== FRONTEND ==========
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This PR updates the CI pipeline to use Node.js 22 with GitHub Actions v5 and fixes SPA routing on Vercel.

## Changes

- Upgrade `actions/checkout` and `actions/setup-node` from v4 to v5
- Update Node.js version from 20 to 22 in CI
- Add `vercel.json` to fix client-side routing (React Router) on Vercel