### PR TITLE
Fix return full catalog - Issue #65

### DIFF
--- a/backend/src/documents/documents.service.ts
+++ b/backend/src/documents/documents.service.ts
@@ -12,11 +12,12 @@ import { FilesService } from '../files/files.service';
 import { EstablishmentType } from '../establishments/enums/establishment-type.enum';
 import { DocumentResponseDto } from './dto/document-response.dto';
 import { GroupedDocumentsResponseDto } from './dto/grouped-documents-response.dto';
+import { FileResponseDto } from 'src/files/dto/file-response.dto';
 
 export interface DocumentUrls {
   logoUrl: string | null;
   coverPhotoUrl: string | null;
-  catalogs: string[];
+  catalogs: FileResponseDto[];
   galleryPhotos: string[];
 }
 
@@ -193,10 +194,8 @@ export class DocumentsService {
   }
 
   /**
-   * Extract all document URLs from already-loaded documents
-   *
-   * @param documents - Array of documents with file relation loaded via JOIN
-   * @returns Object containing document URLs grouped by category
+   * Extracts document URLs from already-loaded documents, grouped by category.
+   * Catalogs are returned as full objects (id, originalFilename, mimeType, size, url).
    */
   getAllDocumentUrls(documents: Document[]): DocumentUrls {
     const result: DocumentUrls = {
@@ -219,7 +218,13 @@ export class DocumentsService {
           result.coverPhotoUrl = url;
           break;
         case DocumentCategory.CATALOG:
-          result.catalogs.push(url);
+          result.catalogs.push({
+            id: doc.file.id,
+            originalFilename: doc.file.originalFilename,
+            mimeType: doc.file.mimeType,
+            size: doc.file.size,
+            url,
+          });
           break;
         case DocumentCategory.GALLERY_PHOTO:
           result.galleryPhotos.push(url);

--- a/backend/src/suppliers/dto/supplier-details.dto.ts
+++ b/backend/src/suppliers/dto/supplier-details.dto.ts
@@ -1,6 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { SupplierListItemDto } from './supplier-list-item.dto';
 import { ReviewDto } from './review.dto';
+import { FileResponseDto } from 'src/files/dto/file-response.dto';
 
 export class SupplierDetailDto extends SupplierListItemDto {
   @ApiPropertyOptional({
@@ -33,14 +34,8 @@ export class SupplierDetailDto extends SupplierListItemDto {
   })
   facebook: string | null;
 
-  @ApiPropertyOptional({
-    example: [
-      'https://le-bon-fournisseur-files.s3.eu-west-3.amazonaws.com/public/catalog1.pdf',
-      'https://le-bon-fournisseur-files.s3.eu-west-3.amazonaws.com/public/catalog2.pdf',
-    ],
-    type: [String],
-  })
-  catalogUrls?: string[];
+  @ApiPropertyOptional({ type: [FileResponseDto] })
+  catalogs: FileResponseDto[];
 
   @ApiPropertyOptional({
     example: [
@@ -49,7 +44,7 @@ export class SupplierDetailDto extends SupplierListItemDto {
     ],
     type: [String],
   })
-  galleryPhotos?: string[];
+  galleryPhotos: string[];
 
   @ApiPropertyOptional({
     type: [ReviewDto],
@@ -62,5 +57,5 @@ export class SupplierDetailDto extends SupplierListItemDto {
       },
     ],
   })
-  reviews?: ReviewDto[];
+  reviews: ReviewDto[];
 }


### PR DESCRIPTION
This PR refactors the catalog document response to return full objects instead of plain URLs.

## Changes

- Add `FileResponseDto` to `DocumentUrls` interface for catalogs
- Update `getAllDocumentUrls` to return full catalog objects (id, originalFilename, mimeType, size, url)
- Update `SupplierDetailDto` to use `FileResponseDto[]` for catalogs instead of `string[]