### PR TITLE
Add ProfilePage documents section - Issue #93

### DIFF
--- a/backend/src/documents/documents.service.ts
+++ b/backend/src/documents/documents.service.ts
@@ -89,7 +89,7 @@ export class DocumentsService {
     const documents = await this.documentsRepository.find({
       where: { establishmentId },
       relations: ['file'],
-      order: { createdAt: 'DESC' },
+      order: { createdAt: 'ASC' },
     });
 
     const grouped: GroupedDocumentsResponseDto = {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -50,12 +50,21 @@ async function bootstrap() {
       .addTag('reviews', 'Reviews and ratings')
       .build(),
   );
-  SwaggerModule.setup('docs', app, document);
+  if (process.env.NODE_ENV !== 'production') {
+    SwaggerModule.setup('docs', app, document);
+  }
 
   const port = process.env.PORT ?? 3000;
   await app.listen(port);
-  console.log(`Application is running on: http://localhost:${port}`);
-  console.log(`Reverse proxy (Nginx): http://localhost:8888`);
-  console.log(`API documentation available at: http://localhost:8888/api/docs`);
+
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(`Backend is running on: http://localhost:${port}`);
+    console.log(
+      `API documentation available at: http://localhost:${port}/docs`,
+    );
+    console.log(`PHPMyAdmin (via Docker): http://localhost:8080`);
+    console.log(`Frontend: http://localhost:5173`);
+    console.log(`Reverse proxy (Nginx): http://localhost:8888`);
+  }
 }
 void bootstrap();

--- a/frontend/src/components/common/ImageWithLoader.tsx
+++ b/frontend/src/components/common/ImageWithLoader.tsx
@@ -4,9 +4,15 @@ type ImageWithLoaderProps = {
   src: string;
   alt: string;
   className?: string;
+  objectFit?: "cover" | "contain";
 };
 
-function ImageWithLoader({ src, alt, className = "" }: ImageWithLoaderProps) {
+function ImageWithLoader({
+  src,
+  alt,
+  className = "",
+  objectFit = "cover",
+}: ImageWithLoaderProps) {
   const [loaded, setLoaded] = useState(false);
 
   return (
@@ -19,7 +25,7 @@ function ImageWithLoader({ src, alt, className = "" }: ImageWithLoaderProps) {
         alt={alt}
         loading="lazy"
         onLoad={() => setLoaded(true)}
-        className={`w-full h-full object-cover rounded-lg transition-opacity duration-300 ease-in-out${
+        className={`w-full h-full ${objectFit === "contain" ? "object-contain" : "object-cover"} rounded-lg transition-opacity duration-300 ease-in-out${
           loaded ? "opacity-100" : "opacity-0"
         }`}
       />

--- a/frontend/src/components/conversations/MessageInput.tsx
+++ b/frontend/src/components/conversations/MessageInput.tsx
@@ -6,6 +6,7 @@ import type { Message } from "../../types/conversations.types";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { UPLOAD_CONFIG } from "@/config/upload.config";
+import { Textarea } from "../ui/textarea";
 
 type PendingFile = {
   id: string;
@@ -138,15 +139,21 @@ function MessageInput({ conversationId, onMessageSent }: MessageInputProps) {
         />
 
         {/* Text input */}
-        <input
-          type="text"
+        <Textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleSubmit(e as any);
+            }
+          }}
           placeholder="Écrire un message"
           disabled={sending}
           className={cn(
-            "flex-1 rounded-lg bg-muted px-3 py-2 text-sm outline-none",
+            "flex-1 min-h-0 max-h-32 resize-none border-none rounded-lg bg-muted px-3 py-2 text-sm outline-none",
             "placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+            "focus-visible:ring-0 focus-visible:border-none",
           )}
         />
 

--- a/frontend/src/components/conversations/MessageInput.tsx
+++ b/frontend/src/components/conversations/MessageInput.tsx
@@ -138,14 +138,14 @@ function MessageInput({ conversationId, onMessageSent }: MessageInputProps) {
           accept={UPLOAD_CONFIG.ACCEPTED_MIME_TYPES}
         />
 
-        {/* Text input */}
+        {/* Message textarea */}
         <Textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
-              handleSubmit(e as any);
+              handleSubmit(e);
             }
           }}
           placeholder="Écrire un message"

--- a/frontend/src/components/documents/DocumentCard.tsx
+++ b/frontend/src/components/documents/DocumentCard.tsx
@@ -1,119 +1,135 @@
-//
-import { ExternalLink, Trash2 } from "lucide-react";
-import { deleteDocument } from "../../api/documents";
-import type { DocumentItem } from "../../types/documents.types";
+import { ExternalLink, X } from "lucide-react";
+import { deleteDocument } from "@/api/documents";
+import type { DocumentItem } from "@/types/documents.types";
 import toast from "react-hot-toast";
 import { useState } from "react";
-import ImageWithLoader from "../common/ImageWithLoader";
+import ImageWithLoader from "@/components/common/ImageWithLoader";
+import { Button } from "@/components/ui/button";
+import { FileText } from "lucide-react";
 
 type DocumentCardProps = {
   document: DocumentItem;
   onDeleteSuccess: () => void;
+  imageFit?: "cover" | "contain";
 };
 
-function DocumentCard({ document, onDeleteSuccess }: DocumentCardProps) {
+function DocumentCard({
+  document,
+  onDeleteSuccess,
+  imageFit = "cover",
+}: DocumentCardProps) {
   const [showConfirm, setShowConfirm] = useState(false);
-
-  const handleTrashClick = () => {
-    setShowConfirm(true);
-  };
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const handleConfirmDelete = async () => {
-    setShowConfirm(false);
+    setIsDeleting(true);
     try {
       await deleteDocument(document.id);
-      toast.success("Document supprimé");
+      toast.success("Document supprimé.");
       onDeleteSuccess();
     } catch (error) {
       console.error("Error deleting document:", error);
-      toast.error("Erreur lors de la suppression du document");
+      toast.error("Erreur lors de la suppression.");
+    } finally {
+      setIsDeleting(false);
+      setShowConfirm(false);
     }
   };
 
-  const handleCancel = () => {
-    setShowConfirm(false);
-  };
-
-  // Image
+  // Image card
   if (document.file.mimeType.startsWith("image/")) {
     return (
-      <div className="relative shadow-md shadow-brand-dark/60 rounded-lg">
+      <div className="relative rounded-lg overflow-hidden">
         <ImageWithLoader
           src={document.file.url}
           alt={document.file.originalFilename}
-          className="w-full h-40"
+          className={"w-full h-36"}
+          objectFit={imageFit}
         />
-        <div className="absolute top-2 right-2">
-          {!showConfirm ? (
-            <button
-              onClick={handleTrashClick}
-              className="btn rounded-full p-1.5 border-2 border-cream"
-              aria-label="Supprimer le document"
-            >
-              <Trash2 className="w-4 h-4" />
-            </button>
-          ) : (
-            <div className="flex flex-col gap-2 bg-white p-3 rounded-lg shadow-lg border border-gray-200">
-              <p className="text-sm font-medium text-brand-light whitespace-nowrap">
-                Supprimer ?
-              </p>
-              <div className="flex gap-2">
-                <button
-                  onClick={handleConfirmDelete}
-                  className="btn text-sm px-3 py-1.5"
-                >
-                  Oui
-                </button>
-                <button
-                  onClick={handleCancel}
-                  className="btn btn-ghost text-brand-light text-sm px-3 py-1.5"
-                >
-                  Non
-                </button>
-              </div>
+        {/* Delete button */}
+        {!showConfirm ? (
+          <button
+            onClick={() => setShowConfirm(true)}
+            className="absolute top-1.5 right-1.5 flex items-center justify-center size-6 rounded-full bg-background/80 hover:bg-background text-foreground transition-colors cursor-pointer"
+            aria-label="Supprimer"
+          >
+            <X className="size-3.5" />
+          </button>
+        ) : (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background/80 rounded-lg">
+            <p className="text-sm font-medium">Supprimer ?</p>
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={handleConfirmDelete}
+                disabled={isDeleting}
+              >
+                Oui
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setShowConfirm(false)}
+                disabled={isDeleting}
+              >
+                Non
+              </Button>
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     );
   }
 
-  // PDF
+  // PDF card
   return (
-    <div className="relative">
-      <div className="bg-white flex items-center gap-3 p-3 shadow-md shadow-brand-dark/60 rounded-lg">
-        <a
-          href={document.file.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex-1  text-brand-light font-medium truncate hover:underline"
-        >
+    <div className="flex items-center gap-3 rounded-lg border border-input-border bg-background px-3 py-2.5">
+      <FileText className="size-4 shrink-0 text-muted-foreground" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">
           {document.file.originalFilename}
-          <ExternalLink className="inline ml-2 w-7 h-7 p-1 transition hover:-translate-y-0.5" />
-        </a>
-
-        <button
-          onClick={handleTrashClick}
-          className="btn rounded-full p-1.5"
-          aria-label="Supprimer le document"
-        >
-          <Trash2 className="w-4 h-4" />
-        </button>
+        </p>
+        <p className="text-xs text-muted-foreground">
+          PDF · {(document.file.size / (1024 * 1024)).toFixed(1)} Mo
+        </p>
       </div>
-      {showConfirm && (
-        <div className="absolute top-full w-full left-0 mt-2 z-10 flex items-center gap-2 bg-white px-4 py-2 rounded-lg shadow-md shadow-brand-dark/60 whitespace-nowrap">
-          <span className="text-sm font-medium text-brand-light mr-4">
-            Supprimer ?
-          </span>
-          <button onClick={handleConfirmDelete} className="btn text-sm py-1.5">
+      <a
+        href={document.file.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 text-muted-foreground hover:text-foreground"
+        aria-label="Ouvrir"
+      >
+        <ExternalLink className="size-4" />
+      </a>
+      {!showConfirm ? (
+        <button
+          onClick={() => setShowConfirm(true)}
+          className="shrink-0 text-muted-foreground hover:text-destructive transition-colors cursor-pointer"
+          aria-label="Supprimer"
+        >
+          <X className="size-4" />
+        </button>
+      ) : (
+        <div className="flex gap-2 shrink-0 align-bottom">
+          <p className="text-sm">Supprimer ?</p>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={handleConfirmDelete}
+            disabled={isDeleting}
+          >
             Oui
-          </button>
-          <button
-            onClick={handleCancel}
-            className="btn btn-ghost text-brand-light text-sm"
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setShowConfirm(false)}
+            disabled={isDeleting}
           >
             Non
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/frontend/src/components/documents/DocumentCard.tsx
+++ b/frontend/src/components/documents/DocumentCard.tsx
@@ -39,7 +39,7 @@ function DocumentCard({
   // Image card
   if (document.file.mimeType.startsWith("image/")) {
     return (
-      <div className="relative rounded-lg overflow-hidden">
+      <div className="relative rounded-lg overflow-hidden width-fit">
         <ImageWithLoader
           src={document.file.url}
           alt={document.file.originalFilename}

--- a/frontend/src/components/documents/DocumentUploadButton.tsx
+++ b/frontend/src/components/documents/DocumentUploadButton.tsx
@@ -1,14 +1,16 @@
 import { useState, type ChangeEvent } from "react";
 import { Upload } from "lucide-react";
 import toast from "react-hot-toast";
-import { uploadDocument } from "../../api/documents";
-import { DocumentCategory } from "../../types/documents.types";
+import { uploadDocument } from "@/api/documents";
+import { DocumentCategory } from "@/types/documents.types";
+import { Button } from "@/components/ui/button";
 
 type DocumentUploadButtonProps = {
   category: DocumentCategory;
-  allowedMimeTypes: string[]; // ["image/png", "image/jpeg", "image/webp"] ou ["application/pdf"]
+  allowedMimeTypes: string[];
   label: string;
   onUploadSuccess: () => void;
+  disabled?: boolean;
 };
 
 function DocumentUploadButton({
@@ -16,27 +18,24 @@ function DocumentUploadButton({
   allowedMimeTypes,
   label,
   onUploadSuccess,
+  disabled = false,
 }: DocumentUploadButtonProps) {
   const [isUploading, setIsUploading] = useState(false);
-  const [helperText, setHelperText] = useState<string | null>(null);
 
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setHelperText(null); // Reset helper text
 
     // Validate file size (20MB max)
     const maxSize = 20 * 1024 * 1024;
     if (file.size > maxSize) {
-      toast.error("Le fichier est trop volumineux.");
-      setHelperText("Taille maximale : 20 Mo");
-      e.target.value = ""; // Reset input
+      toast.error("Le fichier est trop volumineux (20 Mo max).");
+      e.target.value = "";
       return;
     }
 
     // Validate file type
     if (!allowedMimeTypes.includes(file.type)) {
-      toast.error("Type de fichier non autorisé.");
       const formats = allowedMimeTypes.map((type) =>
         type.split("/")[1].toUpperCase(),
       );
@@ -44,40 +43,48 @@ function DocumentUploadButton({
         formats.length > 1
           ? `${formats.slice(0, -1).join(", ")} et ${formats.slice(-1)}`
           : formats[0];
-      setHelperText(`Seuls les fichiers ${formatsText} sont acceptés.`);
-      e.target.value = ""; // Reset input
+      toast.error(`Format non autorisé. Formats acceptés : ${formatsText}`);
+      e.target.value = "";
       return;
     }
 
     setIsUploading(true);
     try {
       await uploadDocument(file, category);
-      toast.success("Document téléchargé avec succès !");
+      toast.success("Fichier ajouté avec succès !");
       onUploadSuccess();
-      e.target.value = ""; // Reset input
+      e.target.value = "";
     } catch (error) {
       console.error("Upload error:", error);
-      toast.error("Erreur lors du téléchargement");
-      e.target.value = ""; // Reset input
+      toast.error("Erreur lors du téléchargement.");
+      e.target.value = "";
     } finally {
       setIsUploading(false);
     }
   };
 
   return (
-    <div>
-      <label className="btn">
-        <Upload className="w-4 h-4" />
-        <span>{isUploading ? "Téléchargement en cours..." : label}</span>
-        <input
-          type="file"
-          onChange={handleFileChange}
-          disabled={isUploading}
-          className="sr-only"
-        />
-      </label>
-      {helperText && <p className="mt-2 text-sm text-accent">{helperText}</p>}
-    </div>
+    <label className="cursor-pointer">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={isUploading || disabled}
+        asChild
+      >
+        <span>
+          <Upload className="size-4" />
+          {isUploading ? "Téléchargement..." : label}
+        </span>
+      </Button>
+      <input
+        type="file"
+        onChange={handleFileChange}
+        disabled={isUploading || disabled}
+        className="sr-only"
+        accept={allowedMimeTypes.join(",")}
+      />
+    </label>
   );
 }
 

--- a/frontend/src/components/documents/DocumentsSection.tsx
+++ b/frontend/src/components/documents/DocumentsSection.tsx
@@ -70,7 +70,7 @@ function DocumentsSection() {
           ) : (
             <div className="flex flex-col gap-8">
               {/* Logo + Cover photo */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-20">
                 {/* Logo */}
                 <div className="flex flex-col gap-2">
                   <div className="flex items-center justify-between">
@@ -80,11 +80,13 @@ function DocumentsSection() {
                     </p>
                   </div>
                   {documents.LOGO[0] ? (
-                    <DocumentCard
-                      document={documents.LOGO[0]}
-                      onDeleteSuccess={fetchDocuments}
-                      imageFit="contain"
-                    />
+                    <div className="flex items-center justify-center h-36">
+                      <DocumentCard
+                        document={documents.LOGO[0]}
+                        onDeleteSuccess={fetchDocuments}
+                        imageFit="contain"
+                      />
+                    </div>
                   ) : (
                     <label className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-input-border bg-muted/30 p-8 cursor-pointer hover:bg-muted/50 transition-colors">
                       <ImageIcon className="size-6 text-muted-foreground" />

--- a/frontend/src/components/documents/DocumentsSection.tsx
+++ b/frontend/src/components/documents/DocumentsSection.tsx
@@ -88,7 +88,7 @@ function DocumentsSection() {
                       />
                     </div>
                   ) : (
-                    <label className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-input-border bg-muted/30 p-8 cursor-pointer hover:bg-muted/50 transition-colors">
+                    <label className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-input-border bg-muted/30 h-36 cursor-pointer hover:bg-muted/50 transition-colors">
                       <ImageIcon className="size-6 text-muted-foreground" />
                       <p className="text-sm text-muted-foreground">
                         Ajouter un logo
@@ -138,7 +138,7 @@ function DocumentsSection() {
                       onDeleteSuccess={fetchDocuments}
                     />
                   ) : (
-                    <label className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-input-border bg-muted/30 p-8 cursor-pointer hover:bg-muted/50 transition-colors">
+                    <label className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-input-border bg-muted/30 h-36 cursor-pointer hover:bg-muted/50 transition-colors">
                       <ImageIcon className="size-6 text-muted-foreground" />
                       <p className="text-sm text-muted-foreground">
                         Ajouter une photo de couverture

--- a/frontend/src/components/documents/DocumentsSection.tsx
+++ b/frontend/src/components/documents/DocumentsSection.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import { ImageIcon } from "lucide-react";
+import { getDocuments } from "@/api/documents";
+import {
+  DocumentCategory,
+  type GroupedDocuments,
+} from "@/types/documents.types";
+import { useAuth } from "@/hooks/useAuth";
+import { EstablishmentType } from "@/types/establishments.types";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Spinner } from "@/components/ui/spinner";
+import DocumentCard from "./DocumentCard";
+import DocumentUploadButton from "./DocumentUploadButton";
+
+const IMAGE_MIME_TYPES = ["image/png", "image/jpeg", "image/webp"];
+const PDF_MIME_TYPES = ["application/pdf"];
+
+function DocumentsSection() {
+  const { user } = useAuth();
+  const isSupplier = user?.establishmentType === EstablishmentType.SUPPLIER;
+
+  const [documents, setDocuments] = useState<GroupedDocuments>({
+    LOGO: [],
+    COVER_PHOTO: [],
+    CATALOG: [],
+    GALLERY_PHOTO: [],
+  });
+  const [loading, setLoading] = useState(true);
+
+  const fetchDocuments = async () => {
+    try {
+      const data = await getDocuments();
+      setDocuments(data);
+    } catch (error) {
+      console.error("Error fetching documents:", error);
+      toast.error("Erreur lors du chargement des documents.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDocuments();
+  }, []);
+
+  return (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="documents">
+        <AccordionTrigger className="flex flex-row w-full gap-8 items-center">
+          <div className="flex flex-row gap-2 items-center">
+            <ImageIcon className="size-4 opacity-70" />
+            <p>Médias &amp; documents</p>
+          </div>
+          <span className="bg-black/10 text-muted-foreground text-xs font-light px-2 py-1 rounded-full">
+            Optionnel
+          </span>
+        </AccordionTrigger>
+
+        <AccordionContent className="p-6 h-auto">
+          {loading ? (
+            <div className="flex justify-center py-8">
+              <Spinner className="size-6 text-muted-foreground" />
+            </div>
+          ) : (
+            <div className="flex flex-col gap-8">
+              {/* Logo + Cover photo */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {/* Logo */}
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium">Logo</p>
+                    <p className="text-xs text-muted-foreground">
+                      PNG, JPG/JPEG, WebP
+                    </p>
+                  </div>
+                  {documents.LOGO[0] ? (
+                    <DocumentCard
+                      document={documents.LOGO[0]}
+                      onDeleteSuccess={fetchDocuments}
+                      imageFit="contain"
+                    />
+                  ) : (
+                    <label className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-input-border bg-muted/30 p-8 cursor-pointer hover:bg-muted/50 transition-colors">
+                      <ImageIcon className="size-6 text-muted-foreground" />
+                      <p className="text-sm text-muted-foreground">
+                        Ajouter un logo
+                      </p>
+                      <input
+                        type="file"
+                        className="sr-only"
+                        accept={IMAGE_MIME_TYPES.join(",")}
+                        onChange={async (e) => {
+                          const file = e.target.files?.[0];
+                          if (!file) return;
+                          if (!IMAGE_MIME_TYPES.includes(file.type)) {
+                            toast.error("Format non autorisé.");
+                            return;
+                          }
+                          if (file.size > 20 * 1024 * 1024) {
+                            toast.error("Fichier trop volumineux (20 Mo max).");
+                            return;
+                          }
+                          try {
+                            const { uploadDocument } =
+                              await import("@/api/documents");
+                            await uploadDocument(file, DocumentCategory.LOGO);
+                            toast.success("Logo ajouté !");
+                            fetchDocuments();
+                          } catch {
+                            toast.error("Erreur lors de l'upload.");
+                          }
+                          e.target.value = "";
+                        }}
+                      />
+                    </label>
+                  )}
+                </div>
+
+                {/* Cover photo */}
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium">Photo de couverture</p>
+                    <p className="text-xs text-muted-foreground">
+                      PNG, JPG/JPEG, WebP
+                    </p>
+                  </div>
+                  {documents.COVER_PHOTO[0] ? (
+                    <DocumentCard
+                      document={documents.COVER_PHOTO[0]}
+                      onDeleteSuccess={fetchDocuments}
+                    />
+                  ) : (
+                    <label className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-input-border bg-muted/30 p-8 cursor-pointer hover:bg-muted/50 transition-colors">
+                      <ImageIcon className="size-6 text-muted-foreground" />
+                      <p className="text-sm text-muted-foreground">
+                        Ajouter une photo de couverture
+                      </p>
+                      <input
+                        type="file"
+                        className="sr-only"
+                        accept={IMAGE_MIME_TYPES.join(",")}
+                        onChange={async (e) => {
+                          const file = e.target.files?.[0];
+                          if (!file) return;
+                          if (!IMAGE_MIME_TYPES.includes(file.type)) {
+                            toast.error("Format non autorisé.");
+                            return;
+                          }
+                          if (file.size > 20 * 1024 * 1024) {
+                            toast.error("Fichier trop volumineux (20 Mo max).");
+                            return;
+                          }
+                          try {
+                            const { uploadDocument } =
+                              await import("@/api/documents");
+                            await uploadDocument(
+                              file,
+                              DocumentCategory.COVER_PHOTO,
+                            );
+                            toast.success("Photo de couverture ajoutée !");
+                            fetchDocuments();
+                          } catch {
+                            toast.error("Erreur lors de l'upload.");
+                          }
+                          e.target.value = "";
+                        }}
+                      />
+                    </label>
+                  )}
+                </div>
+              </div>
+
+              {/* Gallery — supplier only */}
+              {isSupplier && (
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium">Galerie photos</p>
+                    <p className="text-xs text-muted-foreground">
+                      {documents.GALLERY_PHOTO.length}/6 · PNG, JPG/JPEG, WebP
+                    </p>
+                  </div>
+                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
+                    {documents.GALLERY_PHOTO.map((doc) => (
+                      <DocumentCard
+                        key={doc.id}
+                        document={doc}
+                        onDeleteSuccess={fetchDocuments}
+                      />
+                    ))}
+                    {documents.GALLERY_PHOTO.length < 6 && (
+                      <label className="flex flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-input-border bg-muted/30 h-36 cursor-pointer hover:bg-muted/50 transition-colors">
+                        <span className="text-xl text-muted-foreground">+</span>
+                        <p className="text-xs text-muted-foreground">Ajouter</p>
+                        <input
+                          type="file"
+                          className="sr-only"
+                          accept={IMAGE_MIME_TYPES.join(",")}
+                          onChange={async (e) => {
+                            const file = e.target.files?.[0];
+                            if (!file) return;
+                            if (!IMAGE_MIME_TYPES.includes(file.type)) {
+                              toast.error("Format non autorisé.");
+                              return;
+                            }
+                            if (file.size > 20 * 1024 * 1024) {
+                              toast.error(
+                                "Fichier trop volumineux (20 Mo max).",
+                              );
+                              return;
+                            }
+                            try {
+                              const { uploadDocument } =
+                                await import("@/api/documents");
+                              await uploadDocument(
+                                file,
+                                DocumentCategory.GALLERY_PHOTO,
+                              );
+                              toast.success("Photo ajoutée !");
+                              fetchDocuments();
+                            } catch {
+                              toast.error("Erreur lors de l'upload.");
+                            }
+                            e.target.value = "";
+                          }}
+                        />
+                      </label>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {documents.GALLERY_PHOTO.length} / 6 photos
+                  </p>
+                </div>
+              )}
+
+              {/* PDF documents — supplier only */}
+              {isSupplier && (
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium">Autres documents</p>
+                    <p className="text-xs text-muted-foreground">
+                      4 fichiers max · PDF uniquement
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    {documents.CATALOG.map((doc) => (
+                      <DocumentCard
+                        key={doc.id}
+                        document={doc}
+                        onDeleteSuccess={fetchDocuments}
+                      />
+                    ))}
+                  </div>
+                  {documents.CATALOG.length < 4 ? (
+                    <DocumentUploadButton
+                      category={DocumentCategory.CATALOG}
+                      allowedMimeTypes={PDF_MIME_TYPES}
+                      label="Ajouter un document PDF"
+                      onUploadSuccess={fetchDocuments}
+                    />
+                  ) : (
+                    <p className="text-xs text-muted-foreground">
+                      4 documents maximum. Supprimez un document pour en ajouter
+                      un nouveau.
+                    </p>
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    {documents.CATALOG.length} / 4 documents
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+}
+
+export default DocumentsSection;

--- a/frontend/src/components/supplier-details/SupplierDetails.tsx
+++ b/frontend/src/components/supplier-details/SupplierDetails.tsx
@@ -1,0 +1,88 @@
+import api from "@/api/axiosConfig";
+import ReviewsSection from "@/components/reviews/ReviewsSection";
+import AboutSection from "@/components/supplier-details/AboutSection";
+import ContactCard from "@/components/supplier-details/ContactCard";
+import CoverPhoto from "@/components/supplier-details/CoverPhoto";
+import FilesSection from "@/components/supplier-details/FilesSection";
+import GallerySection from "@/components/supplier-details/GallerySection";
+import InfoSection from "@/components/supplier-details/InfoSection";
+import SupplierHeader from "@/components/supplier-details/SupplierHeader";
+import { Spinner } from "@/components/ui/spinner";
+import useCategories from "@/hooks/useCategories";
+import { useFavorites } from "@/hooks/useFavorites";
+import useLabels from "@/hooks/useLabels";
+import type { supplierDetails } from "@/types/supplierDetails.type";
+import { useEffect, useState } from "react";
+
+type SupplierDetailProps = {
+  id: number | string;
+};
+
+function SupplierDetails({ id }: SupplierDetailProps) {
+  const [supplier, setSupplier] = useState<supplierDetails | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { favorites, handleFavoriteToggle } = useFavorites();
+  const { categories } = useCategories();
+  const { labels: allLabels } = useLabels();
+
+  useEffect(() => {
+    async function loadSupplier() {
+      try {
+        setLoading(true);
+        const response = await api.get(`/suppliers/${id}`);
+        setSupplier(response.data);
+      } catch {
+        setError(
+          "Impossible de charger le fournisseur. Veuillez réessayer plus tard.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadSupplier();
+  }, [id]);
+
+  return (
+    <div>
+      {loading && (
+        <div className="flex flex-row w-full items-center justify-center">
+          <Spinner />
+        </div>
+      )}
+
+      {error && <p className="text-destructive">{error}</p>}
+
+      {supplier && (
+        <div className="gap-6">
+          <CoverPhoto supplier={supplier} />
+          <div className="flex flex-col py-8 px-4 lg:py-12 lg:px-24 gap-6">
+            <SupplierHeader
+              supplier={supplier}
+              categories={categories}
+              allLabels={allLabels}
+              isFavorite={favorites.some((fav) => fav.targetId === supplier.id)}
+              onFavoriteToggle={() => handleFavoriteToggle(supplier.id)}
+            />
+            <hr className="w-full border-t border-border" />
+            <div className="w-full flex flex-col lg:flex-row gap-8 items-start">
+              <div className="w-full flex flex-col gap-2">
+                <AboutSection supplier={supplier} />
+                <InfoSection supplier={supplier} />
+                <ReviewsSection supplierId={supplier.id} />
+                {supplier.galleryPhotos.length > 0 && (
+                  <GallerySection supplier={supplier} />
+                )}
+                {supplier.catalogs.length > 0 && (
+                  <FilesSection supplier={supplier} />
+                )}
+              </div>
+              <ContactCard supplier={supplier} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+export default SupplierDetails;

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -131,7 +131,7 @@ function AppLayout() {
               )}
               {isSupplier && (
                 <>
-                  <NavItem to="/profile">Ma fiche</NavItem>
+                  <NavItem to="/profile">Mon établissement</NavItem>
                   <NavItem to="/supplier/stats">Mes statistiques</NavItem>
                 </>
               )}
@@ -250,7 +250,7 @@ function AppLayout() {
                     icon={<LayoutGrid className="size-4" />}
                     onClick={() => setMobileMenuOpen(false)}
                   >
-                    Ma fiche
+                    Mon établissement
                   </MobileNavItem>
                   <MobileNavItem
                     to="/supplier/stats"

--- a/frontend/src/pages/public/SupplierDetailPage.tsx
+++ b/frontend/src/pages/public/SupplierDetailPage.tsx
@@ -1,86 +1,9 @@
-import api from "@/api/axiosConfig";
-import ReviewsSection from "@/components/reviews/ReviewsSection";
-import AboutSection from "@/components/supplier-details/AboutSection";
-import ContactCard from "@/components/supplier-details/ContactCard";
-import CoverPhoto from "@/components/supplier-details/CoverPhoto";
-import FilesSection from "@/components/supplier-details/FilesSection";
-import GallerySection from "@/components/supplier-details/GallerySection";
-import InfoSection from "@/components/supplier-details/InfoSection";
-import SupplierHeader from "@/components/supplier-details/SupplierHeader";
-import { Spinner } from "@/components/ui/spinner";
-import useCategories from "@/hooks/useCategories";
-import { useFavorites } from "@/hooks/useFavorites";
-import useLabels from "@/hooks/useLabels";
-import type { supplierDetails } from "@/types/supplierDetails.type";
-import { useEffect, useState } from "react";
+import SupplierDetail from "@/components/supplier-details/SupplierDetails";
 import { useParams } from "react-router-dom";
 
 function SupplierDetailPage() {
   const { id } = useParams();
-  const [supplier, setSupplier] = useState<supplierDetails | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const { favorites, handleFavoriteToggle } = useFavorites();
-  const { categories } = useCategories();
-  const { labels: allLabels } = useLabels();
 
-  useEffect(() => {
-    async function loadSupplier() {
-      try {
-        setLoading(true);
-        const response = await api.get(`/suppliers/${id}`);
-        setSupplier(response.data);
-      } catch {
-        setError(
-          "Impossible de charger le fournisseur. Veuillez réessayer plus tard.",
-        );
-      } finally {
-        setLoading(false);
-      }
-    }
-    loadSupplier();
-  }, [id]);
-
-  return (
-    <div>
-      {loading && (
-        <div className="flex flex-row w-full items-center justify-center">
-          <Spinner />
-        </div>
-      )}
-
-      {error && <p className="text-destructive">{error}</p>}
-
-      {supplier && (
-        <div className="gap-6">
-          <CoverPhoto supplier={supplier} />
-          <div className="flex flex-col py-8 px-4 lg:py-12 lg:px-24 gap-6">
-            <SupplierHeader
-              supplier={supplier}
-              categories={categories}
-              allLabels={allLabels}
-              isFavorite={favorites.some((fav) => fav.targetId === supplier.id)}
-              onFavoriteToggle={() => handleFavoriteToggle(supplier.id)}
-            />
-            <hr className="w-full border-t border-border" />
-            <div className="w-full flex flex-col lg:flex-row gap-8 items-start">
-              <div className="w-full flex flex-col gap-2">
-                <AboutSection supplier={supplier} />
-                <InfoSection supplier={supplier} />
-                <ReviewsSection supplierId={supplier.id} />
-                {supplier.galleryPhotos.length > 0 && (
-                  <GallerySection supplier={supplier} />
-                )}
-                {supplier.catalogs.length > 0 && (
-                  <FilesSection supplier={supplier} />
-                )}
-              </div>
-              <ContactCard supplier={supplier} />
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+  return <SupplierDetail id={id!} />;
 }
 export default SupplierDetailPage;

--- a/frontend/src/pages/shared/ProfilePage.tsx
+++ b/frontend/src/pages/shared/ProfilePage.tsx
@@ -7,10 +7,21 @@ import useEstablishment from "@/hooks/useEstablishment";
 import useSupplier from "@/hooks/useSupplier";
 import ProfileProgress from "@/components/profile/supplier-extras/ProfileProgress";
 import DocumentsSection from "@/components/documents/DocumentsSection";
+import { useState } from "react";
+import { ExternalLink, X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import SupplierDetails from "@/components/supplier-details/SupplierDetails";
+import { Button } from "@/components/ui/button";
 
 export default function ProfilePage() {
   const { user } = useAuth();
   const type = user?.establishmentType;
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   const {
     editionValues,
@@ -35,7 +46,45 @@ export default function ProfilePage() {
   return (
     <div className="px-4 lg:px-8 py-8 lg:py-12 gap-6 flex flex-col max-w-7xl mx-auto w-full">
       <div className="flex flex-col">
-        <h3>Mon établissement</h3>
+        <div className="flex items-center justify-between">
+          <h3>Mon établissement</h3>
+          {type === "SUPPLIER" && (
+            <>
+              <Button
+                size="sm"
+                onClick={() => setPreviewOpen(true)}
+                className="flex items-center gap-1.5"
+              >
+                <ExternalLink className="size-4" />
+                Voir ma fiche
+              </Button>
+
+              <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+                <DialogContent
+                  className="sm:max-w-6xl w-full max-h-[90vh] overflow-y-auto p-0"
+                  showCloseButton={false}
+                >
+                  <DialogTitle className="sr-only">
+                    Aperçu de ma fiche
+                  </DialogTitle>
+                  <DialogDescription className="sr-only">
+                    Aperçu de votre fiche fournisseur telle qu'elle apparaît aux
+                    restaurants.
+                  </DialogDescription>
+                  <div className="relative rounded-xl overflow-hidden">
+                    <button
+                      onClick={() => setPreviewOpen(false)}
+                      className="absolute top-4 right-2 z-50 mr-2 flex items-center justify-center size-8 rounded-full bg-background border border-border shadow-md hover:bg-muted transition-colors cursor-pointer"
+                    >
+                      <X className="size-4" />
+                    </button>
+                    <SupplierDetails id={user?.establishmentId as number} />
+                  </div>
+                </DialogContent>
+              </Dialog>
+            </>
+          )}
+        </div>
         {type === "SUPPLIER" && (
           <div className="flex flex-col -space-y-5.5 ">
             <p className="text-muted-foreground max-w-10/12 lg:w-full">

--- a/frontend/src/pages/shared/ProfilePage.tsx
+++ b/frontend/src/pages/shared/ProfilePage.tsx
@@ -6,6 +6,7 @@ import { Spinner } from "@/components/ui/spinner";
 import useEstablishment from "@/hooks/useEstablishment";
 import useSupplier from "@/hooks/useSupplier";
 import ProfileProgress from "@/components/profile/supplier-extras/ProfileProgress";
+import DocumentsSection from "@/components/documents/DocumentsSection";
 
 export default function ProfilePage() {
   const { user } = useAuth();
@@ -32,7 +33,7 @@ export default function ProfilePage() {
   } = useSupplier();
 
   return (
-    <div className="px-4 py-8 lg:py-12 lg:px-24 gap-6 flex flex-col">
+    <div className="px-4 lg:px-8 py-8 lg:py-12 gap-6 flex flex-col max-w-7xl mx-auto w-full">
       <div className="flex flex-col">
         <h3>Mon établissement</h3>
         {type === "SUPPLIER" && (
@@ -72,7 +73,7 @@ export default function ProfilePage() {
                   patchEstablishment={patchEstablishment}
                   fieldErrors={fieldErrors}
                 />
-                {/* Documents à ajouter */}
+                <DocumentsSection />
               </>
             )}
           </div>

--- a/frontend/src/pages/supplier/StatisticsPage.tsx
+++ b/frontend/src/pages/supplier/StatisticsPage.tsx
@@ -66,8 +66,8 @@ export default function StatisticsPage() {
   }
 
   return (
-    <div className="px-4 lg:px-24 py-8 flex flex-col gap-8">
-      <h2>Mes statistiques</h2>
+    <div className="px-4 lg:px-8 py-8 lg:py-12 flex flex-col gap-8 max-w-7xl mx-auto w-full">
+      <h3>Mes statistiques</h3>
 
       {/* Stats cards */}
       {stats && (


### PR DESCRIPTION
This PR adds the documents section to the ProfilePage, allowing suppliers and restaurants to manage their logo, cover photo, gallery and PDF documents.

## Changes

- Add `DocumentsSection` accordion component to `ProfilePage` for managing logo, cover photo, gallery and PDF documents
- Refactor `DocumentCard` and `DocumentUploadButton` with new UI using shadcn components
- Add `imageFit` prop to `DocumentCard` and `objectFit` prop to `ImageWithLoader`
- Add supplier preview modal ("Voir ma fiche") in `ProfilePage` using `SupplierDetails` component
- Refactor `SupplierDetailPage` to use the new reusable `SupplierDetails` component
- Replace `input` with auto-resizing `Textarea` in `MessageInput`
- Add responsive `max-w-7xl` layout to `ProfilePage` and `StatisticsPage`
- Rename "Ma fiche" to "Mon établissement" in navigation
- Disable Swagger and verbose logs in production
- Fix gallery photos ordering (ASC by creation date)