### PR TITLE
Reset scroll on route change and pagination - Issue #120

### DIFF
--- a/frontend/src/layouts/RootLayout.tsx
+++ b/frontend/src/layouts/RootLayout.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { Outlet, useLocation } from "react-router-dom";
+
+function RootLayout() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return <Outlet />;
+}
+
+export default RootLayout;

--- a/frontend/src/pages/public/HomePage.tsx
+++ b/frontend/src/pages/public/HomePage.tsx
@@ -79,13 +79,19 @@ function HomePage() {
           <div className="flex flex-row justify-center items-center gap-2">
             <Button
               variant="outline"
-              onClick={() => setPage(page - 1)}
+              onClick={() => {
+                setPage(page - 1);
+                window.scrollTo(0, 0);
+              }}
               disabled={page === 0}
             >
               Précédent
             </Button>
             <Button
-              onClick={() => setPage(page + 1)}
+              onClick={() => {
+                setPage(page + 1);
+                window.scrollTo(0, 0);
+              }}
               disabled={(page + 1) * LIMIT >= suppliers.length}
             >
               Suivant

--- a/frontend/src/routes/index.ts
+++ b/frontend/src/routes/index.ts
@@ -29,110 +29,118 @@ import ProtectedRoute from "./ProtectedRoute";
 import EstablishmentRequiredRoute from "./EstablishmentRequiredRoute";
 import RestaurantRoute from "./RestaurantRoute";
 import SupplierRoute from "./SupplierRoute";
+import RootLayout from "@/layouts/RootLayout";
 
 export const router = createBrowserRouter([
-  // Public routes with PublicLayout
   {
-    Component: PublicLayout,
+    Component: RootLayout,
     children: [
-      { path: "/how-it-works", Component: HowItWorksPage },
-      { path: "/legal", Component: LegalPage },
-      { path: "/privacy", Component: PrivacyPage },
-      { path: "/terms", Component: TermsPage },
-    ],
-  },
-
-  // Routes with AdaptativeLayout:
-  // - Authenticated restaurants => AppLayout
-  // - Visitors (unauthenticated) => PublicLayout
-  // - Authenticated suppliers => redirected to /profile
-  {
-    Component: AdaptativeLayout,
-    children: [
-      { path: "/", Component: HomePage },
-      { path: "/suppliers/:id", Component: SupplierDetailPage },
-    ],
-  },
-
-  // Style guide (dev only)
-  {
-    path: "/style",
-    Component: StylePage,
-  },
-
-  // Auth and Onboarding routes with AuthLayout
-  {
-    Component: AuthLayout,
-    children: [
-      { path: "/login", Component: LoginPage },
-      { path: "/register", Component: RegisterPage },
-
-      // User must be authenticated
+      // Public routes with PublicLayout
       {
-        Component: ProtectedRoute,
+        Component: PublicLayout,
         children: [
+          { path: "/how-it-works", Component: HowItWorksPage },
+          { path: "/legal", Component: LegalPage },
+          { path: "/privacy", Component: PrivacyPage },
+          { path: "/terms", Component: TermsPage },
+        ],
+      },
+
+      // Routes with AdaptativeLayout:
+      // - Authenticated restaurants => AppLayout
+      // - Visitors (unauthenticated) => PublicLayout
+      // - Authenticated suppliers => redirected to /profile
+      {
+        Component: AdaptativeLayout,
+        children: [
+          { path: "/", Component: HomePage },
+          { path: "/suppliers/:id", Component: SupplierDetailPage },
+        ],
+      },
+
+      // Style guide (dev only)
+      {
+        path: "/style",
+        Component: StylePage,
+      },
+
+      // Auth and Onboarding routes with AuthLayout
+      {
+        Component: AuthLayout,
+        children: [
+          { path: "/login", Component: LoginPage },
+          { path: "/register", Component: RegisterPage },
+
+          // User must be authenticated
           {
-            path: "/onboarding/create-establishment",
-            Component: CreateEstablishmentPage,
-          },
-          // User must have an establishment
-          {
-            Component: EstablishmentRequiredRoute,
+            Component: ProtectedRoute,
             children: [
               {
-                path: "/onboarding/supplier-profile",
-                Component: SupplierProfilePage,
+                path: "/onboarding/create-establishment",
+                Component: CreateEstablishmentPage,
+              },
+              // User must have an establishment
+              {
+                Component: EstablishmentRequiredRoute,
+                children: [
+                  {
+                    path: "/onboarding/supplier-profile",
+                    Component: SupplierProfilePage,
+                  },
+                ],
               },
             ],
           },
         ],
       },
-    ],
-  },
 
-  //Confirmation - No layout, User must have an establishment
-  {
-    Component: EstablishmentRequiredRoute,
-    children: [
-      { path: "/onboarding/confirmation", Component: ConfirmationPage },
-    ],
-  },
-
-  // Establishment required routes with AppLayout
-  {
-    Component: EstablishmentRequiredRoute,
-    children: [
+      //Confirmation - No layout, User must have an establishment
       {
-        Component: AppLayout,
+        Component: EstablishmentRequiredRoute,
         children: [
-          // Shared pages
-          { path: "/profile", Component: ProfilePage },
+          { path: "/onboarding/confirmation", Component: ConfirmationPage },
+        ],
+      },
+
+      // Establishment required routes with AppLayout
+      {
+        Component: EstablishmentRequiredRoute,
+        children: [
           {
-            path: "/conversations",
-            Component: ConversationsLayout,
+            Component: AppLayout,
             children: [
-              { index: true, Component: ConversationsEmptyState },
-              { path: ":id", Component: ConversationDetailPage },
+              // Shared pages
+              { path: "/profile", Component: ProfilePage },
+              {
+                path: "/conversations",
+                Component: ConversationsLayout,
+                children: [
+                  { index: true, Component: ConversationsEmptyState },
+                  { path: ":id", Component: ConversationDetailPage },
+                ],
+              },
+              { path: "/settings", Component: SettingsPage },
+
+              // Restaurant routes (Establishment type must be RESTAURANT)
+              {
+                Component: RestaurantRoute,
+                children: [{ path: "/favorites", Component: FavoritesPage }],
+              },
+
+              // Supplier routes (Establishment type must be SUPPLIER)
+              {
+                Component: SupplierRoute,
+                children: [
+                  { path: "/supplier/stats", Component: StatisticsPage },
+                ],
+              },
             ],
-          },
-          { path: "/settings", Component: SettingsPage },
-
-          // Restaurant routes (Establishment type must be RESTAURANT)
-          {
-            Component: RestaurantRoute,
-            children: [{ path: "/favorites", Component: FavoritesPage }],
-          },
-
-          // Supplier routes (Establishment type must be SUPPLIER)
-          {
-            Component: SupplierRoute,
-            children: [{ path: "/supplier/stats", Component: StatisticsPage }],
           },
         ],
       },
+
+      // Catch-all route for 404 Not Found
+      { path: "*", Component: NotFoundPage },
     ],
   },
-
-  // Catch-all route for 404 Not Found
-  { path: "*", Component: NotFoundPage },
 ]);


### PR DESCRIPTION
This PR fixes scroll position not resetting when navigating between routes or paginating through suppliers (issue #120).

- Add `ScrollToTop` behavior in `RootLayout` to reset scroll on every route change
- Reset scroll on previous/next pagination in `HomePage`