### PR TITLE
Add integration tests conversations API  - Issue #125

### DIFF
--- a/backend/src/conversations/conversations.integration.spec.ts
+++ b/backend/src/conversations/conversations.integration.spec.ts
@@ -40,9 +40,11 @@ import {
   mockDocumentsService,
 } from './test/conversations.mocks';
 import { MessageAttachmentResponseDto } from './dto/message-attachments-response.dto';
+import { Server } from 'http';
 
 describe('Conversations API (integration)', () => {
   let app: INestApplication;
+  let server: Server;
 
   // Setup
   beforeEach(async () => {
@@ -100,6 +102,8 @@ describe('Conversations API (integration)', () => {
     );
 
     await app.init();
+
+    server = app.getHttpServer() as Server;
   });
 
   afterEach(async () => {
@@ -118,7 +122,7 @@ describe('Conversations API (integration)', () => {
       mockConversationsRepository.save.mockResolvedValue(mockConversation);
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post('/conversations')
         .send({ supplierId: SUPPLIER_ID });
 
@@ -138,7 +142,7 @@ describe('Conversations API (integration)', () => {
       mockEstablishmentsRepository.findOne.mockResolvedValue(null);
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post('/conversations')
         .send({ supplierId: nonExistentSupplierId });
 
@@ -151,7 +155,7 @@ describe('Conversations API (integration)', () => {
       const bodyWithoutSupplierId = {};
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post('/conversations')
         .send(bodyWithoutSupplierId);
 
@@ -164,7 +168,7 @@ describe('Conversations API (integration)', () => {
       const bodyWithInvalidSupplierId = { supplierId: 'invalid' };
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post('/conversations')
         .send(bodyWithInvalidSupplierId);
 
@@ -188,7 +192,7 @@ describe('Conversations API (integration)', () => {
       mockMessagesRepository.save.mockResolvedValue(undefined);
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post(`/conversations/${CONVERSATION_ID}/messages/1/attachments`)
         .attach('attachment', Buffer.from('fake file content'), 'doc.pdf');
 
@@ -209,7 +213,7 @@ describe('Conversations API (integration)', () => {
       mockMessagesRepository.findOne.mockResolvedValue(null);
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post(`/conversations/${CONVERSATION_ID}/messages/999/attachments`)
         .attach('attachment', Buffer.from('fake file content'), 'doc.pdf');
 
@@ -232,7 +236,7 @@ describe('Conversations API (integration)', () => {
       mockMessagesRepository.findOne.mockResolvedValue(message);
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post(`/conversations/${CONVERSATION_ID}/messages/1/attachments`)
         .attach('attachment', Buffer.from('fake file content'), 'doc.pdf');
 
@@ -245,7 +249,7 @@ describe('Conversations API (integration)', () => {
       const bodyWithoutAttachment = {};
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post(`/conversations/${CONVERSATION_ID}/messages/1/attachments`)
         .send(bodyWithoutAttachment);
 
@@ -261,7 +265,7 @@ describe('Conversations API (integration)', () => {
       mockConversationsRepository.find.mockResolvedValue([]);
 
       // Act
-      const response = await request(app.getHttpServer()).get('/conversations');
+      const response = await request(server).get('/conversations');
 
       // Assert
       expect(response.status).toBe(200);
@@ -294,7 +298,7 @@ describe('Conversations API (integration)', () => {
       });
 
       // Act
-      const response = await request(app.getHttpServer()).get('/conversations');
+      const response = await request(server).get('/conversations');
 
       // Assert
       const body = response.body as ConversationResponseDto[];
@@ -330,9 +334,7 @@ describe('Conversations API (integration)', () => {
       );
 
       // Act
-      const response = await request(app.getHttpServer()).get(
-        '/conversations/unread-count',
-      );
+      const response = await request(server).get('/conversations/unread-count');
 
       // Assert
       const body = response.body as UnreadCountResponseDto;
@@ -363,7 +365,7 @@ describe('Conversations API (integration)', () => {
       mockConversationsRepository.update.mockResolvedValue(undefined);
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post(`/conversations/${CONVERSATION_ID}/messages`)
         .send({ content: 'Hello' });
 
@@ -385,7 +387,7 @@ describe('Conversations API (integration)', () => {
       const bodyWithoutContentOrAttachment = {};
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post(`/conversations/${CONVERSATION_ID}/messages`)
         .send(bodyWithoutContentOrAttachment);
 
@@ -398,7 +400,7 @@ describe('Conversations API (integration)', () => {
       mockConversationsRepository.findOne.mockResolvedValue(null);
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post(`/conversations/${CONVERSATION_ID}/messages`)
         .send({ content: 'Hello' });
 
@@ -415,7 +417,7 @@ describe('Conversations API (integration)', () => {
       });
 
       // Act
-      const response = await request(app.getHttpServer())
+      const response = await request(server)
         .post(`/conversations/${CONVERSATION_ID}/messages`)
         .send({ content: 'Hello' });
 
@@ -444,7 +446,7 @@ describe('Conversations API (integration)', () => {
       mockMessagesRepository.find.mockResolvedValue(messages);
 
       // Act
-      const response = await request(app.getHttpServer()).get(
+      const response = await request(server).get(
         `/conversations/${CONVERSATION_ID}/messages`,
       );
 
@@ -467,7 +469,7 @@ describe('Conversations API (integration)', () => {
       mockConversationsRepository.findOne.mockResolvedValue(null);
 
       // Act
-      const response = await request(app.getHttpServer()).get(
+      const response = await request(server).get(
         `/conversations/${CONVERSATION_ID}/messages`,
       );
 
@@ -484,7 +486,7 @@ describe('Conversations API (integration)', () => {
       });
 
       // Act
-      const response = await request(app.getHttpServer()).get(
+      const response = await request(server).get(
         `/conversations/${CONVERSATION_ID}/messages`,
       );
 
@@ -507,7 +509,7 @@ describe('Conversations API (integration)', () => {
       mockFilesService.getPrivateFileSignedUrl.mockResolvedValue(SIGNED_URL);
 
       // Act
-      const response = await request(app.getHttpServer()).get(
+      const response = await request(server).get(
         `/conversations/${CONVERSATION_ID}/messages/1/attachments/${mockStoredFile.id}`,
       );
 
@@ -525,7 +527,7 @@ describe('Conversations API (integration)', () => {
       mockMessagesRepository.findOne.mockResolvedValue(null);
 
       // Act
-      const response = await request(app.getHttpServer()).get(
+      const response = await request(server).get(
         `/conversations/${CONVERSATION_ID}/messages/999/attachments/1`,
       );
 
@@ -548,7 +550,7 @@ describe('Conversations API (integration)', () => {
       mockMessagesRepository.findOne.mockResolvedValue(message);
 
       // Act
-      const response = await request(app.getHttpServer()).get(
+      const response = await request(server).get(
         `/conversations/${CONVERSATION_ID}/messages/1/attachments/${mockStoredFile.id}`,
       );
 

--- a/backend/src/conversations/conversations.integration.spec.ts
+++ b/backend/src/conversations/conversations.integration.spec.ts
@@ -1,0 +1,559 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  INestApplication,
+  ValidationPipe,
+  ClassSerializerInterceptor,
+  ExecutionContext,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import request from 'supertest';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConversationsController } from './conversations.controller';
+import { ConversationsService } from './conversations.service';
+import { Conversation } from './entities/conversation.entity';
+import { ConversationResponseDto } from './dto/conversation-response.dto';
+import { MessageResponseDto } from './dto/message-response.dto';
+import { UnreadCountResponseDto } from './dto/unread-count-response.dto';
+import { Message } from './entities/message.entity';
+import { Establishment } from 'src/establishments/entities/establishment.entity';
+import { FilesService } from 'src/files/files.service';
+import { DocumentsService } from 'src/documents/documents.service';
+import { EstablishmentGuard } from 'src/common/guards/establishment.guard';
+import { EstablishmentType } from 'src/establishments/enums/establishment-type.enum';
+import {
+  RESTAURANT_ID,
+  SUPPLIER_ID,
+  CONVERSATION_ID,
+  LOGO_URL,
+  SIGNED_URL,
+  mockStoredFile,
+  mockConversation,
+  mockSupplierEstablishment,
+  mockConversationWithRelations,
+  mockRestaurantUser,
+} from './test/conversations.fixtures';
+import {
+  mockConversationsRepository,
+  mockMessagesRepository,
+  mockEstablishmentsRepository,
+  mockFilesService,
+  mockDocumentsService,
+} from './test/conversations.mocks';
+import { MessageAttachmentResponseDto } from './dto/message-attachments-response.dto';
+
+describe('Conversations API (integration)', () => {
+  let app: INestApplication;
+
+  // Setup
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [ConversationsController],
+      providers: [
+        ConversationsService,
+        {
+          provide: getRepositoryToken(Conversation),
+          useValue: mockConversationsRepository,
+        },
+        {
+          provide: getRepositoryToken(Message),
+          useValue: mockMessagesRepository,
+        },
+        {
+          provide: getRepositoryToken(Establishment),
+          useValue: mockEstablishmentsRepository,
+        },
+        {
+          provide: FilesService,
+          useValue: mockFilesService,
+        },
+        {
+          provide: DocumentsService,
+          useValue: mockDocumentsService,
+        },
+      ],
+    })
+      .overrideGuard(EstablishmentGuard)
+      .useValue({
+        canActivate: (context: ExecutionContext) => {
+          const req = context
+            .switchToHttp()
+            .getRequest<Record<string, unknown>>();
+          req.user = mockRestaurantUser;
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalInterceptors(
+      new ClassSerializerInterceptor(app.get(Reflector)),
+    );
+
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  // POST /conversations
+  describe('POST /conversations', () => {
+    test('returns 201 and the conversation when created successfully', async () => {
+      // Arrange
+      mockEstablishmentsRepository.findOne.mockResolvedValue({
+        id: SUPPLIER_ID,
+      });
+      mockConversationsRepository.findOne.mockResolvedValue(null);
+      mockConversationsRepository.create.mockReturnValue(mockConversation);
+      mockConversationsRepository.save.mockResolvedValue(mockConversation);
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/conversations')
+        .send({ supplierId: SUPPLIER_ID });
+
+      // Assert
+      const body = response.body as Conversation;
+      expect(response.status).toBe(201);
+      expect(body).toMatchObject({
+        id: expect.any(Number) as number,
+        restaurantId: RESTAURANT_ID,
+        supplierId: SUPPLIER_ID,
+      });
+    });
+
+    test('returns 404 when supplier does not exist', async () => {
+      // Arrange
+      const nonExistentSupplierId = 999;
+      mockEstablishmentsRepository.findOne.mockResolvedValue(null);
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/conversations')
+        .send({ supplierId: nonExistentSupplierId });
+
+      // Assert
+      expect(response.status).toBe(404);
+    });
+
+    test('returns 400 when supplierId is missing', async () => {
+      // Arrange
+      const bodyWithoutSupplierId = {};
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/conversations')
+        .send(bodyWithoutSupplierId);
+
+      // Assert
+      expect(response.status).toBe(400);
+    });
+
+    test('returns 400 when supplierId is not a number', async () => {
+      // Arrange
+      const bodyWithInvalidSupplierId = { supplierId: 'invalid' };
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/conversations')
+        .send(bodyWithInvalidSupplierId);
+
+      // Assert
+      expect(response.status).toBe(400);
+    });
+  });
+
+  // POST /conversations/:id/messages/:messageId/attachments
+  describe('POST /conversations/:id/messages/:messageId/attachments', () => {
+    test('returns 201 and the attachment response when upload is successful', async () => {
+      // Arrange
+      const message = {
+        id: 1,
+        conversationId: CONVERSATION_ID,
+        conversation: mockConversation,
+        files: [],
+      };
+      mockMessagesRepository.findOne.mockResolvedValue(message);
+      mockFilesService.create.mockResolvedValue(mockStoredFile);
+      mockMessagesRepository.save.mockResolvedValue(undefined);
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post(`/conversations/${CONVERSATION_ID}/messages/1/attachments`)
+        .attach('attachment', Buffer.from('fake file content'), 'doc.pdf');
+
+      // Assert
+      const body = response.body as MessageAttachmentResponseDto;
+      expect(response.status).toBe(201);
+      expect(body).toMatchObject({
+        id: expect.any(Number) as number,
+        originalFilename: expect.any(String) as string,
+        mimeType: expect.any(String) as string,
+        size: expect.any(Number) as number,
+        endpoint: expect.any(String) as string,
+      });
+    });
+
+    test('returns 404 when message does not exist', async () => {
+      // Arrange
+      mockMessagesRepository.findOne.mockResolvedValue(null);
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post(`/conversations/${CONVERSATION_ID}/messages/999/attachments`)
+        .attach('attachment', Buffer.from('fake file content'), 'doc.pdf');
+
+      // Assert
+      expect(response.status).toBe(404);
+    });
+
+    test('returns 403 when establishment is not a participant', async () => {
+      // Arrange
+      const message = {
+        id: 1,
+        conversationId: CONVERSATION_ID,
+        conversation: {
+          ...mockConversation,
+          restaurantId: 999,
+          supplierId: 888,
+        },
+        files: [],
+      };
+      mockMessagesRepository.findOne.mockResolvedValue(message);
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post(`/conversations/${CONVERSATION_ID}/messages/1/attachments`)
+        .attach('attachment', Buffer.from('fake file content'), 'doc.pdf');
+
+      // Assert
+      expect(response.status).toBe(403);
+    });
+
+    test('returns 422 when no file is attached', async () => {
+      // Arrange
+      const bodyWithoutAttachment = {};
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post(`/conversations/${CONVERSATION_ID}/messages/1/attachments`)
+        .send(bodyWithoutAttachment);
+
+      // Assert
+      expect(response.status).toBe(422);
+    });
+  });
+
+  // GET /conversations
+  describe('GET /conversations', () => {
+    test('returns 200 and empty array when no conversations exist', async () => {
+      // Arrange
+      mockConversationsRepository.find.mockResolvedValue([]);
+
+      // Act
+      const response = await request(app.getHttpServer()).get('/conversations');
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([]);
+    });
+
+    test('returns 200 and conversations with correct structure', async () => {
+      // Arrange
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ conversationId: CONVERSATION_ID, count: '2' }]),
+      };
+      mockConversationsRepository.find.mockResolvedValue([
+        mockConversationWithRelations,
+      ]);
+      mockMessagesRepository.createQueryBuilder.mockReturnValue(
+        mockQueryBuilder,
+      );
+      mockDocumentsService.getAllDocumentUrls.mockReturnValue({
+        logoUrl: LOGO_URL,
+        coverPhotoUrl: null,
+        catalogs: [],
+        galleryPhotos: [],
+      });
+
+      // Act
+      const response = await request(app.getHttpServer()).get('/conversations');
+
+      // Assert
+      const body = response.body as ConversationResponseDto[];
+      expect(response.status).toBe(200);
+      expect(body).toHaveLength(1);
+      expect(body[0]).toMatchObject({
+        id: expect.any(Number) as number,
+        unreadCount: 2,
+        lastMessageAt: null,
+        otherParticipant: {
+          id: SUPPLIER_ID,
+          name: mockSupplierEstablishment.tradeName,
+          avatarUrl: LOGO_URL,
+        },
+      });
+      expect(body[0].otherParticipant).not.toHaveProperty('siret');
+      expect(body[0].otherParticipant).not.toHaveProperty('vatNumber');
+    });
+  });
+
+  // GET /conversations/unread-count
+  describe('GET /conversations/unread-count', () => {
+    test('returns 200 and the unread count', async () => {
+      // Arrange
+      const mockQueryBuilder = {
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(3),
+      };
+      mockMessagesRepository.createQueryBuilder.mockReturnValue(
+        mockQueryBuilder,
+      );
+
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        '/conversations/unread-count',
+      );
+
+      // Assert
+      const body = response.body as UnreadCountResponseDto;
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        count: expect.any(Number) as number,
+      });
+      expect(body.count).toBe(3);
+    });
+  });
+
+  // POST /conversations/:id/messages
+  describe('POST /conversations/:id/messages', () => {
+    test('returns 201 and the message with correct structure', async () => {
+      // Arrange
+      const createdMessage = {
+        id: 10,
+        conversationId: CONVERSATION_ID,
+        senderType: EstablishmentType.RESTAURANT,
+        content: 'Hello',
+        sentAt: new Date().toISOString(),
+        isReadByRecipient: false,
+        attachments: [],
+      };
+      mockConversationsRepository.findOne.mockResolvedValue(mockConversation);
+      mockMessagesRepository.create.mockReturnValue(createdMessage);
+      mockMessagesRepository.save.mockResolvedValue(createdMessage);
+      mockConversationsRepository.update.mockResolvedValue(undefined);
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post(`/conversations/${CONVERSATION_ID}/messages`)
+        .send({ content: 'Hello' });
+
+      // Assert
+      const body = response.body as MessageResponseDto;
+      expect(response.status).toBe(201);
+      expect(body).toMatchObject({
+        id: expect.any(Number) as number,
+        conversationId: CONVERSATION_ID,
+        senderType: EstablishmentType.RESTAURANT,
+        content: 'Hello',
+        isReadByRecipient: false,
+        attachments: [],
+      });
+    });
+
+    test('returns 400 when content and attachment are both missing', async () => {
+      // Arrange
+      const bodyWithoutContentOrAttachment = {};
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post(`/conversations/${CONVERSATION_ID}/messages`)
+        .send(bodyWithoutContentOrAttachment);
+
+      // Assert
+      expect(response.status).toBe(400);
+    });
+
+    test('returns 404 when conversation does not exist', async () => {
+      // Arrange
+      mockConversationsRepository.findOne.mockResolvedValue(null);
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post(`/conversations/${CONVERSATION_ID}/messages`)
+        .send({ content: 'Hello' });
+
+      // Assert
+      expect(response.status).toBe(404);
+    });
+
+    test('returns 403 when establishment is not a participant', async () => {
+      // Arrange
+      mockConversationsRepository.findOne.mockResolvedValue({
+        ...mockConversation,
+        restaurantId: 999,
+        supplierId: 888,
+      });
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post(`/conversations/${CONVERSATION_ID}/messages`)
+        .send({ content: 'Hello' });
+
+      // Assert
+      expect(response.status).toBe(403);
+    });
+  });
+
+  // GET /conversations/:id/messages
+  describe('GET /conversations/:id/messages', () => {
+    test('returns 200 and messages with correct structure', async () => {
+      // Arrange
+      const messages = [
+        {
+          id: 1,
+          conversationId: CONVERSATION_ID,
+          senderType: EstablishmentType.SUPPLIER,
+          content: 'Hello',
+          sentAt: new Date(),
+          isReadByRecipient: false,
+          files: [],
+        },
+      ];
+      mockConversationsRepository.findOne.mockResolvedValue(mockConversation);
+      mockMessagesRepository.update.mockResolvedValue(undefined);
+      mockMessagesRepository.find.mockResolvedValue(messages);
+
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        `/conversations/${CONVERSATION_ID}/messages`,
+      );
+
+      // Assert
+      const body = response.body as MessageResponseDto[];
+      expect(response.status).toBe(200);
+      expect(body).toHaveLength(1);
+      expect(body[0]).toMatchObject({
+        id: expect.any(Number) as number,
+        conversationId: CONVERSATION_ID,
+        senderType: EstablishmentType.SUPPLIER,
+        content: 'Hello',
+        isReadByRecipient: expect.any(Boolean) as boolean,
+        attachments: [],
+      });
+    });
+
+    test('returns 404 when conversation does not exist', async () => {
+      // Arrange
+      mockConversationsRepository.findOne.mockResolvedValue(null);
+
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        `/conversations/${CONVERSATION_ID}/messages`,
+      );
+
+      // Assert
+      expect(response.status).toBe(404);
+    });
+
+    test('returns 403 when establishment is not a participant', async () => {
+      // Arrange
+      mockConversationsRepository.findOne.mockResolvedValue({
+        ...mockConversation,
+        restaurantId: 999,
+        supplierId: 888,
+      });
+
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        `/conversations/${CONVERSATION_ID}/messages`,
+      );
+
+      // Assert
+      expect(response.status).toBe(403);
+    });
+  });
+
+  // GET /conversations/:id/messages/:messageId/attachments/:attachmentId
+  describe('GET /conversations/:id/messages/:messageId/attachments/:attachmentId', () => {
+    test('returns 200 and signed URL with correct structure', async () => {
+      // Arrange
+      const message = {
+        id: 1,
+        conversationId: CONVERSATION_ID,
+        conversation: mockConversation,
+        files: [mockStoredFile],
+      };
+      mockMessagesRepository.findOne.mockResolvedValue(message);
+      mockFilesService.getPrivateFileSignedUrl.mockResolvedValue(SIGNED_URL);
+
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        `/conversations/${CONVERSATION_ID}/messages/1/attachments/${mockStoredFile.id}`,
+      );
+
+      // Assert
+      const body = response.body as { url: string };
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        url: expect.any(String) as string,
+      });
+      expect(body.url).toBe(SIGNED_URL);
+    });
+
+    test('returns 404 when message does not exist', async () => {
+      // Arrange
+      mockMessagesRepository.findOne.mockResolvedValue(null);
+
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        `/conversations/${CONVERSATION_ID}/messages/999/attachments/1`,
+      );
+
+      // Assert
+      expect(response.status).toBe(404);
+    });
+
+    test('returns 403 when establishment is not a participant', async () => {
+      // Arrange
+      const message = {
+        id: 1,
+        conversationId: CONVERSATION_ID,
+        conversation: {
+          ...mockConversation,
+          restaurantId: 999,
+          supplierId: 888,
+        },
+        files: [mockStoredFile],
+      };
+      mockMessagesRepository.findOne.mockResolvedValue(message);
+
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        `/conversations/${CONVERSATION_ID}/messages/1/attachments/${mockStoredFile.id}`,
+      );
+
+      // Assert
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/backend/src/conversations/conversations.service.spec.ts
+++ b/backend/src/conversations/conversations.service.spec.ts
@@ -8,94 +8,28 @@ import { FilesService } from 'src/files/files.service';
 import { DocumentsService } from 'src/documents/documents.service';
 import { EstablishmentType } from 'src/establishments/enums/establishment-type.enum';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
-import { Document as EstablishmentDocument } from 'src/documents/entities/document.entity';
-import { StoredFile } from 'src/files/entities/stored-file.entity';
-import { DocumentCategory } from 'src/documents/enums/document.enum';
+import {
+  RESTAURANT_ID,
+  SUPPLIER_ID,
+  CONVERSATION_ID,
+  MESSAGE_CONTENT,
+  LOGO_URL,
+  SIGNED_URL,
+  mockStoredFile,
+  mockConversation,
+  mockSupplierEstablishment,
+  mockConversationWithRelations,
+} from './test/conversations.fixtures';
+import {
+  mockConversationsRepository,
+  mockMessagesRepository,
+  mockEstablishmentsRepository,
+  mockFilesService,
+  mockDocumentsService,
+} from './test/conversations.mocks';
 
 describe('ConversationsService', () => {
   let service: ConversationsService;
-
-  // Fixtures
-  const RESTAURANT_ID = 3;
-  const SUPPLIER_ID = 5;
-  const CONVERSATION_ID = 1;
-  const MESSAGE_CONTENT = 'Hello';
-  const LOGO_URL = 'https://bucket.s3.amazonaws.com/public/logo.jpg';
-  const SIGNED_URL =
-    'https://bucket.s3.amazonaws.com/private/doc.pdf?X-Amz-Signature=abc';
-
-  const mockStoredFile: StoredFile = {
-    id: 7,
-    path: 'public/logo.jpg',
-    originalFilename: 'logo.jpg',
-    mimeType: 'image/jpeg',
-    size: 2048,
-    uploadedAt: new Date(),
-    documents: [],
-    messages: [],
-  };
-
-  const mockDocument: EstablishmentDocument = {
-    id: 1,
-    establishmentId: SUPPLIER_ID,
-    fileId: mockStoredFile.id,
-    category: DocumentCategory.LOGO,
-    createdAt: new Date(),
-    file: mockStoredFile,
-    establishment: {} as Establishment,
-  };
-
-  const mockConversation: Partial<Conversation> = {
-    id: CONVERSATION_ID,
-    restaurantId: RESTAURANT_ID,
-    supplierId: SUPPLIER_ID,
-  };
-
-  const mockSupplierEstablishment: Partial<Establishment> = {
-    id: SUPPLIER_ID,
-    tradeName: 'Fruits Bio',
-    legalName: 'Fruits Bio SARL',
-    documents: [mockDocument],
-  };
-
-  const mockConversationWithRelations: Partial<Conversation> = {
-    ...mockConversation,
-    supplier: mockSupplierEstablishment as Establishment,
-    lastMessageAt: null,
-  };
-
-  // Mocks for repositories and services
-  const mockConversationsRepository = {
-    findOne: jest.fn(),
-    create: jest.fn(),
-    save: jest.fn(),
-    find: jest.fn(),
-    update: jest.fn(),
-    createQueryBuilder: jest.fn(),
-  };
-
-  const mockMessagesRepository = {
-    findOne: jest.fn(),
-    create: jest.fn(),
-    save: jest.fn(),
-    find: jest.fn(),
-    update: jest.fn(),
-    createQueryBuilder: jest.fn(),
-  };
-
-  const mockEstablishmentsRepository = {
-    findOne: jest.fn(),
-  };
-
-  const mockFilesService = {
-    create: jest.fn(),
-    getPrivateFileSignedUrl: jest.fn(),
-    getPublicFileUrl: jest.fn(),
-  };
-
-  const mockDocumentsService = {
-    getAllDocumentUrls: jest.fn(),
-  };
 
   // Setup
   beforeEach(async () => {
@@ -342,6 +276,132 @@ describe('ConversationsService', () => {
     });
   });
 
+  // sendAttachment
+  describe('sendAttachment', () => {
+    test('should throw NotFoundException when message does not exist', async () => {
+      // Arrange
+      const mockFile = {
+        originalname: 'doc.pdf',
+        mimetype: 'application/pdf',
+        size: 1024,
+        buffer: Buffer.from(''),
+      } as Express.Multer.File;
+      mockMessagesRepository.findOne.mockResolvedValue(null);
+
+      // Act
+      const act = () =>
+        service.sendAttachment(
+          CONVERSATION_ID,
+          1,
+          RESTAURANT_ID,
+          EstablishmentType.RESTAURANT,
+          mockFile,
+        );
+
+      // Assert
+      await expect(act()).rejects.toThrow(NotFoundException);
+    });
+
+    test('should throw ForbiddenException when message does not belong to conversation', async () => {
+      // Arrange
+      const mockFile = {
+        originalname: 'doc.pdf',
+        mimetype: 'application/pdf',
+        size: 1024,
+        buffer: Buffer.from(''),
+      } as Express.Multer.File;
+      const messageFromOtherConversation = {
+        id: 1,
+        conversationId: 999,
+        conversation: { ...mockConversation, id: 999 },
+        files: [],
+      };
+      mockMessagesRepository.findOne.mockResolvedValue(
+        messageFromOtherConversation,
+      );
+
+      // Act
+      const act = () =>
+        service.sendAttachment(
+          CONVERSATION_ID,
+          1,
+          RESTAURANT_ID,
+          EstablishmentType.RESTAURANT,
+          mockFile,
+        );
+
+      // Assert
+      await expect(act()).rejects.toThrow(ForbiddenException);
+    });
+
+    test('should throw ForbiddenException when establishment is not a participant', async () => {
+      // Arrange
+      const outsiderEstablishmentId = 99;
+      const mockFile = {
+        originalname: 'doc.pdf',
+        mimetype: 'application/pdf',
+        size: 1024,
+        buffer: Buffer.from(''),
+      } as Express.Multer.File;
+      const message = {
+        id: 1,
+        conversationId: CONVERSATION_ID,
+        conversation: mockConversation,
+        files: [],
+      };
+      mockMessagesRepository.findOne.mockResolvedValue(message);
+
+      // Act
+      const act = () =>
+        service.sendAttachment(
+          CONVERSATION_ID,
+          1,
+          outsiderEstablishmentId,
+          EstablishmentType.RESTAURANT,
+          mockFile,
+        );
+
+      // Assert
+      await expect(act()).rejects.toThrow(ForbiddenException);
+    });
+
+    test('should upload attachment and return attachment response', async () => {
+      // Arrange
+      const mockFile = {
+        originalname: 'doc.pdf',
+        mimetype: 'application/pdf',
+        size: 1024,
+        buffer: Buffer.from(''),
+      } as Express.Multer.File;
+      const message = {
+        id: 1,
+        conversationId: CONVERSATION_ID,
+        conversation: mockConversation,
+        files: [],
+      };
+      mockMessagesRepository.findOne.mockResolvedValue(message);
+      mockFilesService.create.mockResolvedValue(mockStoredFile);
+      mockMessagesRepository.save.mockResolvedValue(undefined);
+
+      // Act
+      const result = await service.sendAttachment(
+        CONVERSATION_ID,
+        1,
+        RESTAURANT_ID,
+        EstablishmentType.RESTAURANT,
+        mockFile,
+      );
+
+      // Assert
+      expect(mockFilesService.create).toHaveBeenCalledWith(mockFile, 'private');
+      expect(mockMessagesRepository.save).toHaveBeenCalled();
+      expect(result.originalFilename).toBe(mockStoredFile.originalFilename);
+      expect(result.endpoint).toBe(
+        `/conversations/${CONVERSATION_ID}/messages/1/attachments/${mockStoredFile.id}`,
+      );
+    });
+  });
+
   // getConversationMessages
   describe('getConversationMessages', () => {
     test('should throw NotFoundException when conversation does not exist', async () => {
@@ -508,6 +568,28 @@ describe('ConversationsService', () => {
       // Assert
       expect(result).toEqual({ count: 0 });
     });
+
+    test('should return the total unread count for a supplier', async () => {
+      // Arrange
+      const mockQueryBuilder = {
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(5),
+      };
+      mockMessagesRepository.createQueryBuilder.mockReturnValue(
+        mockQueryBuilder,
+      );
+
+      // Act
+      const result = await service.getTotalUnreadCount(
+        SUPPLIER_ID,
+        EstablishmentType.SUPPLIER,
+      );
+
+      // Assert
+      expect(result).toEqual({ count: 5 });
+    });
   });
 
   // getConversations
@@ -600,6 +682,89 @@ describe('ConversationsService', () => {
       // Assert
       expect(result[0].unreadCount).toBe(0);
       expect(result[0].otherParticipant.avatarUrl).toBeNull();
+    });
+
+    test('should not expose internal establishment fields in otherParticipant', async () => {
+      // Arrange
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      mockConversationsRepository.find.mockResolvedValue([
+        mockConversationWithRelations,
+      ]);
+      mockMessagesRepository.createQueryBuilder.mockReturnValue(
+        mockQueryBuilder,
+      );
+      mockDocumentsService.getAllDocumentUrls.mockReturnValue({
+        logoUrl: null,
+        coverPhotoUrl: null,
+        catalogs: [],
+        galleryPhotos: [],
+      });
+
+      // Act
+      const result = await service.getConversations(
+        RESTAURANT_ID,
+        EstablishmentType.RESTAURANT,
+      );
+
+      // Assert
+      expect(result[0].otherParticipant).not.toHaveProperty('siret');
+      expect(result[0].otherParticipant).not.toHaveProperty('vatNumber');
+    });
+
+    test('should return conversations for a supplier with restaurant as otherParticipant', async () => {
+      // Arrange
+      const mockRestaurantEstablishment: Partial<Establishment> = {
+        id: RESTAURANT_ID,
+        tradeName: 'Le Gourmet',
+        legalName: 'Le Gourmet SARL',
+        documents: [],
+      };
+      const mockConversationWithRestaurant: Partial<Conversation> = {
+        ...mockConversation,
+        restaurant: mockRestaurantEstablishment as Establishment,
+        lastMessageAt: null,
+      };
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      mockConversationsRepository.find.mockResolvedValue([
+        mockConversationWithRestaurant,
+      ]);
+      mockMessagesRepository.createQueryBuilder.mockReturnValue(
+        mockQueryBuilder,
+      );
+      mockDocumentsService.getAllDocumentUrls.mockReturnValue({
+        logoUrl: null,
+        coverPhotoUrl: null,
+        catalogs: [],
+        galleryPhotos: [],
+      });
+
+      // Act
+      const result = await service.getConversations(
+        SUPPLIER_ID,
+        EstablishmentType.SUPPLIER,
+      );
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0].otherParticipant.id).toBe(RESTAURANT_ID);
+      expect(result[0].otherParticipant.name).toBe(
+        mockRestaurantEstablishment.tradeName,
+      );
+      expect(result[0].unreadCount).toBe(0);
     });
   });
 

--- a/backend/src/conversations/test/conversations.fixtures.ts
+++ b/backend/src/conversations/test/conversations.fixtures.ts
@@ -1,0 +1,61 @@
+import { Establishment } from 'src/establishments/entities/establishment.entity';
+import { StoredFile } from 'src/files/entities/stored-file.entity';
+import { Document as EstablishmentDocument } from 'src/documents/entities/document.entity';
+import { DocumentCategory } from 'src/documents/enums/document.enum';
+import { Conversation } from '../entities/conversation.entity';
+import { EstablishmentType } from 'src/establishments/enums/establishment-type.enum';
+
+export const RESTAURANT_ID = 3;
+export const SUPPLIER_ID = 5;
+export const CONVERSATION_ID = 1;
+export const MESSAGE_CONTENT = 'Hello';
+export const LOGO_URL = 'https://bucket.s3.amazonaws.com/public/logo.jpg';
+export const SIGNED_URL =
+  'https://bucket.s3.amazonaws.com/private/doc.pdf?X-Amz-Signature=abc';
+
+export const mockStoredFile: StoredFile = {
+  id: 7,
+  path: 'public/logo.jpg',
+  originalFilename: 'logo.jpg',
+  mimeType: 'image/jpeg',
+  size: 2048,
+  uploadedAt: new Date(),
+  documents: [],
+  messages: [],
+};
+
+export const mockDocument: EstablishmentDocument = {
+  id: 1,
+  establishmentId: SUPPLIER_ID,
+  fileId: mockStoredFile.id,
+  category: DocumentCategory.LOGO,
+  createdAt: new Date(),
+  file: mockStoredFile,
+  establishment: {} as Establishment,
+};
+
+export const mockConversation: Partial<Conversation> = {
+  id: CONVERSATION_ID,
+  restaurantId: RESTAURANT_ID,
+  supplierId: SUPPLIER_ID,
+  lastMessageAt: null,
+};
+
+export const mockSupplierEstablishment: Partial<Establishment> = {
+  id: SUPPLIER_ID,
+  tradeName: 'Fruits Bio',
+  legalName: 'Fruits Bio SARL',
+  documents: [mockDocument],
+};
+
+export const mockConversationWithRelations: Partial<Conversation> = {
+  ...mockConversation,
+  supplier: mockSupplierEstablishment as Establishment,
+  lastMessageAt: null,
+};
+
+export const mockRestaurantUser = {
+  id: 1,
+  establishmentId: RESTAURANT_ID,
+  establishmentType: EstablishmentType.RESTAURANT,
+};

--- a/backend/src/conversations/test/conversations.mocks.ts
+++ b/backend/src/conversations/test/conversations.mocks.ts
@@ -1,0 +1,31 @@
+export const mockConversationsRepository = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+  update: jest.fn(),
+  createQueryBuilder: jest.fn(),
+};
+
+export const mockMessagesRepository = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+  update: jest.fn(),
+  createQueryBuilder: jest.fn(),
+};
+
+export const mockEstablishmentsRepository = {
+  findOne: jest.fn(),
+};
+
+export const mockFilesService = {
+  create: jest.fn(),
+  getPrivateFileSignedUrl: jest.fn(),
+  getPublicFileUrl: jest.fn(),
+};
+
+export const mockDocumentsService = {
+  getAllDocumentUrls: jest.fn(),
+};


### PR DESCRIPTION
This PR adds integration tests for the conversations API, along with shared fixtures and mocks, and completes the unit test coverage for `ConversationsService`.

## Changes
- Add shared fixtures and mocks in `src/conversations/test/`
- Add integration tests covering all conversations routes (POST, GET, 403, 404, 400, 422)
- Add missing unit tests for `sendAttachment` and supplier branch in `getConversations` and `getTotalUnreadCount`

## Test results
- 31 unit tests passing
- 21 integration tests passing