### PR TITLE
Add E2E test for conversation journey - Issue #127

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -27,3 +27,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright test results
+test-results/
+playwright-report/

--- a/frontend/e2e/conversation-journey.spec.ts
+++ b/frontend/e2e/conversation-journey.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+
+const TEST_EMAIL = "hello@bouchonlyonnais.com";
+const TEST_PASSWORD = "Password123!";
+
+test.describe("Conversation journey", () => {
+  test("restaurant user can login, contact a supplier and send a message", async ({
+    page,
+  }) => {
+    // Arrange
+    const TEST_MESSAGE = `Test E2E - ${Date.now()}`;
+    await page.goto("/login");
+
+    // Act : login
+    await page.getByLabel("Adresse e-mail").fill(TEST_EMAIL);
+    await page.locator("#password").fill(TEST_PASSWORD);
+    await page.getByRole("button", { name: "Se connecter" }).click();
+
+    // Assert : redirected to home page
+    await expect(page).toHaveURL("/");
+    await expect(page.getByTestId("supplier-card").first()).toBeVisible();
+
+    // Act : click on first supplier card
+    await page.getByTestId("supplier-card").first().click();
+
+    // Assert : on supplier detail page
+    await expect(page).toHaveURL(/\/suppliers\/\d+/);
+
+    // Act : click contact button
+    await page
+      .getByRole("button", { name: "Contacter le fournisseur" })
+      .click();
+
+    // Assert : redirected to conversation page
+    await expect(page).toHaveURL(/\/conversations\/\d+/);
+
+    // Act : type and send a message
+    await page
+      .getByRole("textbox", { name: "Écrire un message" })
+      .fill(TEST_MESSAGE);
+    await page.getByRole("button", { name: "Envoyer" }).click();
+
+    // Assert : message appears in the conversation
+    await expect(page.getByText(TEST_MESSAGE)).toBeVisible();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,11 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",

--- a/frontend/src/components/conversations/MessageInput.tsx
+++ b/frontend/src/components/conversations/MessageInput.tsx
@@ -149,6 +149,7 @@ function MessageInput({ conversationId, onMessageSent }: MessageInputProps) {
             }
           }}
           placeholder="Écrire un message"
+          aria-label="Écrire un message"
           disabled={sending}
           className={cn(
             "flex-1 min-h-0 max-h-32 resize-none border-none rounded-lg bg-muted px-3 py-2 text-sm outline-none",


### PR DESCRIPTION
This PR adds an E2E test covering the full conversation journey for a restaurant user.

## Changes
- Add `conversation-journey.spec.ts` : login, contact a supplier, send a message
- Add `aria-label` on message textarea for accessible selector
- Add E2E scripts in `package.json` (`test:e2e`, `test:e2e:headed`, `test:e2e:ui`, `test:e2e:debug`)
- Update `.gitignore` to exclude `test-results/` and `playwright-report/`

## Test result
2 passed (conversation journey + supplier search from Lisa)