### PR TITLE
Redirect user to requested conversation after authentication - Issue #132

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from "../../hooks/useAuth";
-import { useNavigate, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useState, type ChangeEvent, type FormEvent } from "react";
 import toast from "react-hot-toast";
 import axios from "axios";
@@ -8,7 +8,7 @@ import { Eye, EyeOff, Mail } from "lucide-react";
 import { Field, FieldError, FieldGroup, FieldLabel } from "../ui/field";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
-import { EstablishmentType } from "@/types/establishments.types";
+import { useRedirectAfterAuth } from "@/hooks/useRedirectAfterAuth";
 
 type LoginFormErrors = {
   email?: string;
@@ -18,7 +18,7 @@ type LoginFormErrors = {
 
 function LoginForm() {
   const { login } = useAuth();
-  const navigate = useNavigate();
+  const { redirectAfterAuth } = useRedirectAfterAuth();
   const [showPassword, setShowPassword] = useState(false);
 
   const [formData, setFormData] = useState({
@@ -80,14 +80,7 @@ function LoginForm() {
 
       toast.success(`Bienvenue ${user.firstName} !`);
 
-      // Redirect based on establishment
-      if (!user.establishmentId) {
-        navigate("/onboarding/create-establishment");
-      } else if (user.establishmentType === EstablishmentType.RESTAURANT) {
-        navigate("/");
-      } else {
-        navigate("/profile");
-      }
+      await redirectAfterAuth(user.establishmentType, user.establishmentId);
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 401) {
         setErrors({ general: "Email ou mot de passe incorrect." });

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from "../../hooks/useAuth";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, Link, useLocation } from "react-router-dom";
 import { useState, type ChangeEvent, type FormEvent } from "react";
 import toast from "react-hot-toast";
 import axios from "axios";
@@ -32,6 +32,7 @@ type RegisterFormErrors = {
 
 function RegisterForm() {
   const { register } = useAuth();
+  const location = useLocation();
   const navigate = useNavigate();
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -142,7 +143,9 @@ function RegisterForm() {
         acceptTerms,
       });
 
-      navigate("/onboarding/create-establishment");
+      navigate("/onboarding/create-establishment", {
+        state: location.state,
+      });
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 409) {
         setErrors({ email: "Cet email est déjà utilisé." });
@@ -349,6 +352,7 @@ function RegisterForm() {
       <p className="text-center text-sm mt-2">
         <Link
           to="/login"
+          state={location.state}
           className="font-medium text-primary-mid hover:primary"
         >
           Connexion

--- a/frontend/src/components/conversations/ContactButton.tsx
+++ b/frontend/src/components/conversations/ContactButton.tsx
@@ -4,7 +4,7 @@ import toast from "react-hot-toast";
 import { createConversation } from "../../api/conversations";
 import { Button } from "../ui/button";
 import { useAuth } from "@/hooks/useAuth";
-import { LockKeyhole, MessageCircle } from "lucide-react";
+import { MessageCircle } from "lucide-react";
 
 type ContactButtonProps = {
   supplierId: number;
@@ -17,11 +17,7 @@ function ContactButton({ supplierId }: ContactButtonProps) {
 
   const handleContactClick = async () => {
     if (!user) {
-      toast("Connectez-vous pour contacter ce fournisseur", {
-        id: "contact-login",
-        className: "text-primary border-2 border-primary-mid",
-        icon: <LockKeyhole className="size-4 text-primary-mid" />,
-      });
+      navigate("/register", { state: { supplierId } });
       return;
     }
     setLoading(true);
@@ -38,7 +34,9 @@ function ContactButton({ supplierId }: ContactButtonProps) {
 
   return (
     <Button onClick={handleContactClick} disabled={loading}>
-      <span className="hidden lg:inline">{loading ? "Chargement..." : "Contacter le fournisseur"}</span>
+      <span className="hidden lg:inline">
+        {loading ? "Chargement..." : "Contacter le fournisseur"}
+      </span>
       <MessageCircle className="lg:hidden w-4 h-4"></MessageCircle>
     </Button>
   );

--- a/frontend/src/components/onboarding/CreateEstablishmentForm.tsx
+++ b/frontend/src/components/onboarding/CreateEstablishmentForm.tsx
@@ -10,7 +10,7 @@ import {
 import axios from "axios";
 import { useState, type ChangeEvent, type FormEvent } from "react";
 import toast from "react-hot-toast";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   Field,
   FieldContent,
@@ -50,8 +50,9 @@ type CreateEstablishmentErrors = {
 };
 
 function CreateEstablishmentForm() {
+  const location = useLocation();
   const navigate = useNavigate();
-  const { refreshUser } = useAuth();
+  const { refreshUser, logout } = useAuth();
 
   const [formData, setFormData] = useState<CreateEstablishmentFormData>({
     type: null,
@@ -163,7 +164,9 @@ function CreateEstablishmentForm() {
       if (type === EstablishmentType.SUPPLIER) {
         navigate("/onboarding/supplier-profile");
       } else {
-        navigate("/onboarding/confirmation");
+        navigate("/onboarding/confirmation", {
+          state: location.state,
+        });
       }
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 409) {
@@ -386,7 +389,11 @@ function CreateEstablishmentForm() {
       </form>
       <p className="mt-4 text-sm">
         Besoin de reprendre plus tard?{" "}
-        <Link to="/" className="text-primary-mid font-bold">
+        <Link
+          to="/"
+          onClick={() => logout()}
+          className="text-primary-mid font-bold"
+        >
           Quitter
         </Link>{" "}
         <span className="text-sm">

--- a/frontend/src/hooks/useRedirectAfterAuth.ts
+++ b/frontend/src/hooks/useRedirectAfterAuth.ts
@@ -1,0 +1,41 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { createConversation } from "@/api/conversations";
+import { EstablishmentType } from "@/types/establishments.types";
+import type { ContactButtonLocationState } from "@/types/navigation.types";
+
+export function useRedirectAfterAuth() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = location.state as ContactButtonLocationState | undefined;
+  const supplierId = state?.supplierId;
+
+  const redirectAfterAuth = async (
+    establishmentType: EstablishmentType | null,
+    establishmentId: number | null,
+  ) => {
+    if (!establishmentId) {
+      navigate("/onboarding/create-establishment", { state });
+      return;
+    }
+
+    if (supplierId && establishmentType === EstablishmentType.RESTAURANT) {
+      try {
+        const conversation = await createConversation(supplierId);
+        navigate(`/conversations/${conversation.id}`);
+        return;
+      } catch (error) {
+        console.error("Error creating conversation:", error);
+        navigate("/");
+        return;
+      }
+    }
+
+    if (establishmentType === EstablishmentType.SUPPLIER) {
+      navigate("/profile");
+      return;
+    }
+    navigate("/");
+  };
+
+  return { redirectAfterAuth };
+}

--- a/frontend/src/pages/onboarding/ConfirmationPage.tsx
+++ b/frontend/src/pages/onboarding/ConfirmationPage.tsx
@@ -1,17 +1,22 @@
-import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
-import { EstablishmentType } from "@/types/establishments.types";
 import { Button } from "@/components/ui/button";
+import { useState } from "react";
+import { useRedirectAfterAuth } from "@/hooks/useRedirectAfterAuth";
 
 function ConfirmationPage() {
-  const navigate = useNavigate();
   const { user } = useAuth();
+  const { redirectAfterAuth } = useRedirectAfterAuth();
+  const [loading, setLoading] = useState(false);
 
-  const handleStart = () => {
-    if (user?.establishmentType === EstablishmentType.SUPPLIER) {
-      navigate("/profile");
-    } else {
-      navigate("/");
+  const handleStart = async () => {
+    setLoading(true);
+    try {
+      await redirectAfterAuth(
+        user?.establishmentType ?? null,
+        user?.establishmentId ?? null,
+      );
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -37,10 +42,11 @@ function ConfirmationPage() {
       {/* CTA */}
       <Button
         onClick={handleStart}
+        disabled={loading}
         size="sm"
         className="w-full max-w-sm bg-primary-foreground text-primary hover:bg-primary-foreground/90"
       >
-        Commencer
+        {loading ? "Chargement..." : "Commencer"}
       </Button>
     </main>
   );

--- a/frontend/src/types/navigation.types.ts
+++ b/frontend/src/types/navigation.types.ts
@@ -1,0 +1,3 @@
+export type ContactButtonLocationState = {
+  supplierId?: number;
+};


### PR DESCRIPTION
This PR implements a redirect flow so that a visitor who clicks "Contacter le fournisseur" is redirected to the requested conversation after completing authentication.

## Changes
- Add `ContactButtonLocationState` type in `navigation.types.ts`
- Add `useRedirectAfterAuth` hook centralizing post-auth navigation logic
- Update `ContactButton` to navigate to `/register` with `supplierId` in state
- Update `RegisterForm` to propagate state to next onboarding step and to login link
- Update `CreateEstablishmentForm` to propagate state to confirmation page
- Update `ConfirmationPage` to use `useRedirectAfterAuth`
- Update `LoginForm` to use `useRedirectAfterAuth`
- Update `CreateEstablishmentForm` to logout user on "Quitter"