### PR TITLE
Fix legal pages styling - Issue #134

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -134,9 +134,16 @@
   }
 
   h4 {
-      font-family: var(--font-heading);
-      font-weight: 700;
-      font-size: 1rem;
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: 1rem;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    color: var(--foreground);
   }
 
   * {

--- a/frontend/src/pages/public/LegalPage.tsx
+++ b/frontend/src/pages/public/LegalPage.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
-
 import { Button } from "@/components/ui/button";
 
 function LegalPage() {
@@ -8,7 +7,7 @@ function LegalPage() {
 
   return (
     <main className="max-w-4xl mx-auto px-6 py-12">
-      <Button onClick={() => navigate(-1)} className="mb-8">
+      <Button onClick={() => navigate(-1)} className="mb-8" size="lg">
         <ArrowLeft />
         Retour
       </Button>
@@ -18,17 +17,19 @@ function LegalPage() {
         Dernière mise à jour : juin 2026
       </p>
 
-      <section className="space-y-8">
+      <section className="space-y-6 text-sm text-muted-foreground">
         <div>
-          <h2 className="mb-3">Éditeur de la plateforme</h2>
+          <h2 className="text-xl font-semibold mb-1">
+            Éditeur de la plateforme
+          </h2>
           <p>
-            <strong>Le Bon Fournisseur</strong>
+            <strong className="text-foreground">Le Bon Fournisseur</strong>
           </p>
-          <p className="mt-2">
+          <p>
             Projet réalisé dans le cadre du module MyDigitalProject de
             MyDigitalSchool Lyon.
           </p>
-          <p className="mt-2">
+          <p>
             Contact : contact@lebonfournisseur.fr
             <br />
             SIRET : 123 456 789 00011
@@ -36,12 +37,14 @@ function LegalPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Responsable de publication</h2>
+          <h2 className="text-xl font-semibold mb-1">
+            Responsable de publication
+          </h2>
           <p>L'équipe projet Le Bon Fournisseur.</p>
         </div>
 
         <div>
-          <h2 className="mb-3">Hébergement</h2>
+          <h2 className="text-xl font-semibold mb-1">Hébergement</h2>
           <p>
             L'application est hébergée auprès de prestataires cloud utilisés
             pour le fonctionnement de la plateforme.
@@ -49,20 +52,24 @@ function LegalPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Propriété intellectuelle</h2>
+          <h2 className="text-xl font-semibold mb-1">
+            Propriété intellectuelle
+          </h2>
           <p>
             Les contenus, textes, illustrations, logos et éléments graphiques
             présents sur cette plateforme sont protégés par les règles relatives
             à la propriété intellectuelle.
           </p>
-          <p className="mt-2">
+          <p>
             Toute reproduction ou réutilisation sans autorisation préalable est
             interdite.
           </p>
         </div>
 
         <div>
-          <h2 className="mb-3">Limitation de responsabilité</h2>
+          <h2 className="text-xl font-semibold mb-1">
+            Limitation de responsabilité
+          </h2>
           <p>
             Cette plateforme est présentée dans le cadre d'un projet
             pédagogique. Malgré le soin apporté à son développement, aucune
@@ -72,7 +79,7 @@ function LegalPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Contact</h2>
+          <h2 className="text-xl font-semibold mb-1">Contact</h2>
           <p>
             Pour toute question relative à la plateforme :
             contact@lebonfournisseur.fr
@@ -80,7 +87,7 @@ function LegalPage() {
         </div>
       </section>
 
-      <Button onClick={() => navigate(-1)} className="mt-12">
+      <Button onClick={() => navigate(-1)} className="mt-12" size="lg">
         <ArrowLeft />
         Retour
       </Button>

--- a/frontend/src/pages/public/PrivacyPage.tsx
+++ b/frontend/src/pages/public/PrivacyPage.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
-
 import { Button } from "@/components/ui/button";
 
 function PrivacyPage() {
@@ -8,20 +7,19 @@ function PrivacyPage() {
 
   return (
     <main className="max-w-4xl mx-auto px-6 py-12">
-      <Button onClick={() => navigate(-1)} className="mb-8">
+      <Button onClick={() => navigate(-1)} className="mb-8" size="lg">
         <ArrowLeft />
         Retour
       </Button>
 
       <h1 className="mb-2">Politique de confidentialité</h1>
-
       <p className="text-sm text-muted-foreground mb-10">
         Dernière mise à jour : juin 2026
       </p>
 
-      <section className="space-y-8">
+      <section className="space-y-6 text-sm text-muted-foreground">
         <div>
-          <h2 className="mb-3">Préambule</h2>
+          <h2 className="text-xl font-semibold mb-1">Préambule</h2>
           <p>
             La présente politique de confidentialité décrit comment Le Bon
             Fournisseur collecte, utilise, stocke et protège les données
@@ -30,17 +28,19 @@ function PrivacyPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Données collectées</h2>
+          <h2 className="text-xl font-semibold mb-1">Données collectées</h2>
 
-          <h3 className="mb-2">Données de compte</h3>
-          <ul className="list-disc pl-6 space-y-1">
+          <h3 className="text-base font-semibold mb-1">Données de compte</h3>
+          <ul className="list-disc pl-6">
             <li>Nom et prénom</li>
             <li>Adresse email</li>
             <li>Mot de passe (stocké sous forme hachée)</li>
           </ul>
 
-          <h3 className="mt-6 mb-2">Données de l'établissement</h3>
-          <ul className="list-disc pl-6 space-y-1">
+          <h3 className="text-base font-semibold mb-1 mt-4">
+            Données de l'établissement
+          </h3>
+          <ul className="list-disc pl-6">
             <li>Raison sociale et nom commercial</li>
             <li>Numéro SIRET</li>
             <li>Adresse postale</li>
@@ -48,8 +48,10 @@ function PrivacyPage() {
             <li>Description de l'activité</li>
           </ul>
 
-          <h3 className="mt-6 mb-2">Données spécifiques aux fournisseurs</h3>
-          <ul className="list-disc pl-6 space-y-1">
+          <h3 className="text-base font-semibold mb-1 mt-4">
+            Données spécifiques aux fournisseurs
+          </h3>
+          <ul className="list-disc pl-6">
             <li>Type de fournisseur</li>
             <li>Fourchette de prix</li>
             <li>Catégories de produits</li>
@@ -57,23 +59,25 @@ function PrivacyPage() {
             <li>Documents et photos publiés</li>
           </ul>
 
-          <h3 className="mt-6 mb-2">Données d'utilisation</h3>
-          <ul className="list-disc pl-6 space-y-1">
+          <h3 className="text-base font-semibold mb-1 mt-4">
+            Données d'utilisation
+          </h3>
+          <ul className="list-disc pl-6">
             <li>Messages échangés sur la plateforme</li>
             <li>Favoris enregistrés</li>
             <li>Avis et notes publiés</li>
             <li>Date de création du compte</li>
             <li>Date de dernière connexion</li>
           </ul>
-          <p className="mt-3">
-            La plateforme ne collecte aucune donnée bancaire.
-          </p>
+          <p>La plateforme ne collecte aucune donnée bancaire.</p>
         </div>
 
         <div>
-          <h2 className="mb-3">Finalités du traitement</h2>
+          <h2 className="text-xl font-semibold mb-1">
+            Finalités du traitement
+          </h2>
           <p>Les données sont utilisées afin de :</p>
-          <ul className="list-disc pl-6 mt-3 space-y-1">
+          <ul className="list-disc pl-6">
             <li>Créer et gérer les comptes utilisateurs</li>
             <li>Permettre la mise en relation entre utilisateurs</li>
             <li>Assurer le fonctionnement de la messagerie</li>
@@ -81,13 +85,13 @@ function PrivacyPage() {
             <li>Sécuriser l'accès à la plateforme</li>
             <li>Améliorer les fonctionnalités du service</li>
           </ul>
-          <p className="mt-3">
-            Les données ne sont jamais vendues à des tiers.
-          </p>
+          <p>Les données ne sont jamais vendues à des tiers.</p>
         </div>
 
         <div>
-          <h2 className="mb-3">Base légale du traitement</h2>
+          <h2 className="text-xl font-semibold mb-1">
+            Base légale du traitement
+          </h2>
           <p>
             Le traitement des données repose sur l'exécution du service proposé
             par la plateforme ainsi que sur le consentement de l'utilisateur
@@ -96,7 +100,9 @@ function PrivacyPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Hébergement et stockage</h2>
+          <h2 className="text-xl font-semibold mb-1">
+            Hébergement et stockage
+          </h2>
           <p>
             Les données et documents déposés sur la plateforme sont hébergés
             auprès de prestataires cloud utilisés pour le fonctionnement du
@@ -105,12 +111,12 @@ function PrivacyPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Sécurité des données</h2>
+          <h2 className="text-xl font-semibold mb-1">Sécurité des données</h2>
           <p>
             Des mesures techniques et organisationnelles sont mises en œuvre
             afin de protéger les données :
           </p>
-          <ul className="list-disc pl-6 mt-3 space-y-1">
+          <ul className="list-disc pl-6">
             <li>Authentification sécurisée</li>
             <li>Mots de passe hachés</li>
             <li>Contrôle des autorisations</li>
@@ -120,13 +126,13 @@ function PrivacyPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Partage des données</h2>
+          <h2 className="text-xl font-semibold mb-1">Partage des données</h2>
           <p>Les données ne sont pas partagées à des fins commerciales.</p>
-          <p className="mt-3">
+          <p>
             Certaines informations sont toutefois visibles dans le cadre du
             fonctionnement normal de la plateforme :
           </p>
-          <ul className="list-disc pl-6 mt-3 space-y-1">
+          <ul className="list-disc pl-6">
             <li>Les profils fournisseurs publics</li>
             <li>Les avis publiés</li>
             <li>Les messages échangés entre participants à une conversation</li>
@@ -134,40 +140,42 @@ function PrivacyPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Durée de conservation</h2>
+          <h2 className="text-xl font-semibold mb-1">Durée de conservation</h2>
           <p>
             Les données sont conservées tant que le compte utilisateur reste
             actif.
           </p>
-          <p className="mt-3">
+          <p>
             En cas de suppression du compte, les données associées sont
             supprimées de la plateforme.
           </p>
         </div>
 
         <div>
-          <h2 className="mb-3">Vos droits</h2>
+          <h2 className="text-xl font-semibold mb-1">Vos droits</h2>
           <p>
             Conformément à la réglementation applicable, vous disposez d'un
             droit d'accès, de rectification, d'effacement et d'opposition
             concernant vos données personnelles.
           </p>
-          <p className="mt-3">Contact : contact@lebonfournisseur.fr</p>
+          <p>Contact : contact@lebonfournisseur.fr</p>
         </div>
 
         <div>
-          <h2 className="mb-3">Cookies</h2>
+          <h2 className="text-xl font-semibold mb-1">Cookies</h2>
           <p>
             La plateforme n'utilise pas de cookies publicitaires ou de suivi.
           </p>
-          <p className="mt-3">
+          <p>
             Un identifiant de connexion peut être conservé dans le navigateur
             afin d'assurer le bon fonctionnement du service.
           </p>
         </div>
 
         <div>
-          <h2 className="mb-3">Modification de la politique</h2>
+          <h2 className="text-xl font-semibold mb-1">
+            Modification de la politique
+          </h2>
           <p>
             Cette politique de confidentialité peut être amenée à évoluer. Toute
             modification importante sera communiquée aux utilisateurs via la
@@ -176,7 +184,7 @@ function PrivacyPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Contact</h2>
+          <h2 className="text-xl font-semibold mb-1">Contact</h2>
           <p>
             Pour toute question relative à la protection des données :
             contact@lebonfournisseur.fr
@@ -184,7 +192,7 @@ function PrivacyPage() {
         </div>
       </section>
 
-      <Button onClick={() => navigate(-1)} className="mt-12">
+      <Button onClick={() => navigate(-1)} className="mt-12" size="lg">
         <ArrowLeft />
         Retour
       </Button>

--- a/frontend/src/pages/public/TermsPage.tsx
+++ b/frontend/src/pages/public/TermsPage.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
-
 import { Button } from "@/components/ui/button";
 
 function TermsPage() {
@@ -8,25 +7,24 @@ function TermsPage() {
 
   return (
     <main className="max-w-4xl mx-auto px-6 py-12">
-      <Button onClick={() => navigate(-1)} className="mb-8">
+      <Button onClick={() => navigate(-1)} className="mb-8" size="lg">
         <ArrowLeft />
         Retour
       </Button>
 
       <h1 className="mb-2">Conditions Générales d'Utilisation</h1>
-
       <p className="text-sm text-muted-foreground mb-10">
         Dernière mise à jour : juin 2026
       </p>
 
-      <section className="space-y-8">
+      <section className="space-y-6 text-sm text-muted-foreground">
         <div>
-          <h2 className="mb-3">Présentation</h2>
+          <h2 className="text-xl font-semibold mb-1">Présentation</h2>
           <p>
             Cette plateforme met en relation des restaurants et des fournisseurs
             du secteur alimentaire.
           </p>
-          <p className="mt-3">
+          <p>
             Éditeur : Le Bon Fournisseur
             <br />
             Contact : contact@lebonfournisseur.fr
@@ -36,7 +34,9 @@ function TermsPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Acceptation des conditions</h2>
+          <h2 className="text-xl font-semibold mb-1">
+            Acceptation des conditions
+          </h2>
           <p>
             L'utilisation de la plateforme implique l'acceptation pleine et
             entière des présentes Conditions Générales d'Utilisation.
@@ -44,10 +44,10 @@ function TermsPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Inscription</h2>
+          <h2 className="text-xl font-semibold mb-1">Inscription</h2>
 
-          <h3 className="mb-2">Conditions d'accès</h3>
-          <ul className="list-disc pl-6 space-y-1">
+          <h3 className="text-base font-semibold mb-1">Conditions d'accès</h3>
+          <ul className="list-disc pl-6">
             <li>Professionnels justifiant d'un numéro SIRET valide</li>
             <li>
               Personnes majeures agissant dans le cadre de leur activité
@@ -56,8 +56,10 @@ function TermsPage() {
             <li>Un seul compte par établissement (SIRET unique)</li>
           </ul>
 
-          <h3 className="mt-6 mb-2">Obligations de l'utilisateur</h3>
-          <ul className="list-disc pl-6 space-y-1">
+          <h3 className="text-base font-semibold mb-1 mt-4">
+            Obligations de l'utilisateur
+          </h3>
+          <ul className="list-disc pl-6">
             <li>Fournir des informations exactes et à jour</li>
             <li>Maintenir la confidentialité de ses identifiants</li>
             <li>Ne créer qu'un seul compte par établissement</li>
@@ -65,10 +67,10 @@ function TermsPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Services proposés</h2>
+          <h2 className="text-xl font-semibold mb-1">Services proposés</h2>
 
-          <h3 className="mb-2">Pour les restaurants</h3>
-          <ul className="list-disc pl-6 space-y-1">
+          <h3 className="text-base font-semibold mb-1">Pour les restaurants</h3>
+          <ul className="list-disc pl-6">
             <li>Recherche de fournisseurs</li>
             <li>Gestion des favoris</li>
             <li>Publication d'avis et notes</li>
@@ -76,8 +78,10 @@ function TermsPage() {
             <li>Stockage de documents</li>
           </ul>
 
-          <h3 className="mt-6 mb-2">Pour les fournisseurs</h3>
-          <ul className="list-disc pl-6 space-y-1">
+          <h3 className="text-base font-semibold mb-1 mt-4">
+            Pour les fournisseurs
+          </h3>
+          <ul className="list-disc pl-6">
             <li>Gestion d'une fiche fournisseur détaillée</li>
             <li>Publication de catalogues et documents</li>
             <li>Gestion des labels et certifications</li>
@@ -88,9 +92,10 @@ function TermsPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Obligations des utilisateurs</h2>
-
-          <ul className="list-disc pl-6 space-y-1">
+          <h2 className="text-xl font-semibold mb-1">
+            Obligations des utilisateurs
+          </h2>
+          <ul className="list-disc pl-6">
             <li>
               Utiliser la plateforme de manière loyale et conforme à sa
               destination
@@ -102,17 +107,15 @@ function TermsPage() {
             <li>Publier des informations exactes et sincères</li>
             <li>Respecter la législation en vigueur</li>
           </ul>
-
-          <p className="mt-3">
+          <p>
             En cas de manquement, le compte pourra être suspendu ou supprimé
             sans préavis.
           </p>
         </div>
 
         <div>
-          <h2 className="mb-3">Système d'avis</h2>
-
-          <ul className="list-disc pl-6 space-y-1">
+          <h2 className="text-xl font-semibold mb-1">Système d'avis</h2>
+          <ul className="list-disc pl-6">
             <li>Les avis doivent être basés sur une expérience réelle</li>
             <li>
               Un seul avis par restaurant et par fournisseur (modifiable
@@ -123,39 +126,35 @@ function TermsPage() {
             </li>
             <li>Les fournisseurs disposent d'un droit de réponse</li>
           </ul>
-
-          <p className="mt-3">
+          <p>
             Les avis manifestement diffamatoires, injurieux ou frauduleux
             pourront être supprimés.
           </p>
         </div>
 
         <div>
-          <h2 className="mb-3">Messagerie</h2>
-
+          <h2 className="text-xl font-semibold mb-1">Messagerie</h2>
           <p>
             La plateforme met à disposition un service de messagerie privée
             entre restaurants et fournisseurs.
           </p>
-
-          <ul className="list-disc pl-6 mt-3 space-y-1">
+          <ul className="list-disc pl-6">
             <li>Communication professionnelle uniquement</li>
             <li>Conservation des messages pendant 12 mois</li>
           </ul>
         </div>
 
         <div>
-          <h2 className="mb-3">Protection des données personnelles</h2>
-
+          <h2 className="text-xl font-semibold mb-1">
+            Protection des données personnelles
+          </h2>
           <p>Données collectées :</p>
-
-          <ul className="list-disc pl-6 mt-3 space-y-1">
+          <ul className="list-disc pl-6">
             <li>Nom, prénom et adresse email</li>
             <li>Données de l'établissement</li>
             <li>Avis, messages et documents publiés</li>
           </ul>
-
-          <p className="mt-3">
+          <p>
             Conformément au RGPD, les utilisateurs disposent d'un droit d'accès,
             de rectification, d'effacement, d'opposition et de portabilité de
             leurs données.
@@ -163,14 +162,14 @@ function TermsPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Propriété intellectuelle</h2>
-
+          <h2 className="text-xl font-semibold mb-1">
+            Propriété intellectuelle
+          </h2>
           <p>
             La plateforme, son contenu et sa structure sont protégés par le
             droit de la propriété intellectuelle.
           </p>
-
-          <p className="mt-3">
+          <p>
             Les utilisateurs conservent la propriété des contenus qu'ils
             publient mais accordent à la plateforme une licence d'utilisation
             nécessaire à son fonctionnement.
@@ -178,28 +177,24 @@ function TermsPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Responsabilité</h2>
-
+          <h2 className="text-xl font-semibold mb-1">Responsabilité</h2>
           <p>
             L'éditeur s'engage à mettre en œuvre tous les moyens raisonnables
             pour assurer le bon fonctionnement de la plateforme.
           </p>
-
-          <p className="mt-3">
+          <p>
             Les utilisateurs restent seuls responsables des contenus publiés, de
             leurs échanges et de leurs relations commerciales.
           </p>
         </div>
 
         <div>
-          <h2 className="mb-3">Durée et résiliation</h2>
-
+          <h2 className="text-xl font-semibold mb-1">Durée et résiliation</h2>
           <p>
             L'utilisateur peut supprimer son compte à tout moment depuis son
             espace personnel.
           </p>
-
-          <p className="mt-3">
+          <p>
             Un compte pourra être suspendu ou supprimé en cas de violation des
             présentes CGU, d'informations inexactes ou de comportement
             frauduleux.
@@ -207,8 +202,7 @@ function TermsPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Modification des CGU</h2>
-
+          <h2 className="text-xl font-semibold mb-1">Modification des CGU</h2>
           <p>
             L'éditeur se réserve le droit de modifier les présentes CGU à tout
             moment. La poursuite de l'utilisation de la plateforme vaut
@@ -217,18 +211,17 @@ function TermsPage() {
         </div>
 
         <div>
-          <h2 className="mb-3">Litiges</h2>
-
+          <h2 className="text-xl font-semibold mb-1">Litiges</h2>
           <p>Les présentes CGU sont soumises au droit français.</p>
-
-          <p className="mt-3">
+          <p>
             Pour toute question ou réclamation :
             <br />
             contact@lebonfournisseur.fr
           </p>
         </div>
       </section>
-      <Button onClick={() => navigate(-1)} className="mt-12">
+
+      <Button onClick={() => navigate(-1)} className="mt-12" size="lg">
         <ArrowLeft />
         Retour
       </Button>


### PR DESCRIPTION
This PR fixes the styling of LegalPage, PrivacyPage and TermsPage to match the design.

## Changes
- Reduce heading sizes and spacing
- Set text to `text-muted-foreground` on section content
- Fix heading color inheritance issue in global CSS